### PR TITLE
fix offset error when attemping to save Google Calendar API key in ca…

### DIFF
--- a/includes/abstracts/admin-page.php
+++ b/includes/abstracts/admin-page.php
@@ -179,7 +179,7 @@ abstract class Admin_Page {
 	 */
 	public function validate( $settings ) {
 
-		$sanitized = '';
+		$sanitized = array();
 
 		if ( is_array( $settings ) ) {
 			foreach ( $settings as $k => $v ) {

--- a/readme.txt
+++ b/readme.txt
@@ -96,6 +96,11 @@ We'd love your help! Here's a few things you can do:
 
 == Changelog ==
 
+= 3.1.10 - TBD =
+
+* Fix: Fixed an issue where Google Calendar API key sometimes wouldn't save on the settings page.
+
+
 = 3.1.9 - December 9, 2016 =
 
 * Feature: Add [if-today] and [if-not-today] event template tags. Props [@followfung](https://github.com/followfung)


### PR DESCRIPTION
…lendar settings

- Need to initialize variable as array.