### PR TITLE
Feature/datetime separator spacing

### DIFF
--- a/includes/abstracts/calendar.php
+++ b/includes/abstracts/calendar.php
@@ -575,7 +575,7 @@ abstract class Calendar {
 			$separator = get_post_meta( $this->id, '_calendar_datetime_separator', true );
 		}
 
-		if ( 'yes' !== $separator_spacing ) {
+		if ( empty( $separator_spacing ) ) {
 			$separator = '&nbsp;' . trim( $separator ) . '&nbsp;';
 		} else {
 			$separator = str_replace( ' ', '&nbsp;', $separator );

--- a/includes/abstracts/calendar.php
+++ b/includes/abstracts/calendar.php
@@ -580,7 +580,7 @@ abstract class Calendar {
 		} else {
 			$separator = str_replace( ' ', '&nbsp;', $separator );
 		}
-		$this->datetime_separator = wp_kses_post( $separator );
+		$this->datetime_separator = esc_html( $separator );
 	}
 
 	/**

--- a/includes/abstracts/calendar.php
+++ b/includes/abstracts/calendar.php
@@ -570,11 +570,11 @@ abstract class Calendar {
 	 */
 	public function set_datetime_separator( $separator = '' ) {
 
-		$separator_spacing = get_post_meta( $this->id, '_calendar_datetime_separator_spacing', true );
 		if ( empty( $separator ) ) {
 			$separator = get_post_meta( $this->id, '_calendar_datetime_separator', true );
 		}
 
+		$separator_spacing = get_post_meta( $this->id, '_calendar_datetime_separator_spacing', true );
 		if ( empty( $separator_spacing ) ) {
 			$separator = '&nbsp;' . trim( $separator ) . '&nbsp;';
 		} else {

--- a/includes/abstracts/calendar.php
+++ b/includes/abstracts/calendar.php
@@ -570,11 +570,17 @@ abstract class Calendar {
 	 */
 	public function set_datetime_separator( $separator = '' ) {
 
+		$separator_spacing = get_post_meta( $this->id, '_calendar_datetime_separator_spacing', true );
 		if ( empty( $separator ) ) {
 			$separator = get_post_meta( $this->id, '_calendar_datetime_separator', true );
 		}
 
-		$this->datetime_separator = esc_attr( $separator );
+		if ( 'yes' !== $separator_spacing ) {
+			$separator = '&nbsp;' . trim( $separator ) . '&nbsp;';
+		} else {
+			$separator = str_replace( ' ', '&nbsp;', $separator );
+		}
+		$this->datetime_separator = wp_kses_post( $separator );
 	}
 
 	/**

--- a/includes/admin/metaboxes/settings.php
+++ b/includes/admin/metaboxes/settings.php
@@ -645,7 +645,7 @@ class Settings implements Meta_Box {
 					<?php
 
 					$separator = get_post_meta( $post->ID, '_calendar_datetime_separator', true );
-					$separator = false == $separator ? '@' : $separator;
+					$separator = ( false === $separator ) ? '@' : $separator;
 
 					simcal_print_field( array(
 						'type'    => 'standard',
@@ -654,6 +654,27 @@ class Settings implements Meta_Box {
 						'id'      => '_calendar_datetime_separator',
 						'value'   => $separator,
 						'tooltip' => __( 'Used to divide date and time when both are shown.', 'google-calendar-events' ),
+						'class'   => array(
+							'simcal-field-tiny',
+						),
+					) );
+
+					?>
+				</td>
+			</tr>
+			<tr class="simcal-panel-field">
+				<th><label for="_calendar_datetime_separator_spacing"><?php _e( 'Preserve Separator Spacing', 'google-calendar-events' ); ?></label></th>
+				<td>
+					<?php
+
+					$separator_spacing = get_post_meta( $post->ID, '_calendar_datetime_separator_spacing', true );
+
+					simcal_print_field( array(
+						'type'    => 'checkbox',
+						'name'    => '_calendar_datetime_separator_spacing',
+						'id'      => '_calendar_datetime_separator_spacing',
+						'value'   => 'yes' === $separator_spacing ? 'yes' : 'no',
+						'tooltip' => __( 'Checking this box will use the spacing contained in the separator field above. Otherwise one space on each side of the separator will be used instead.', 'google-calendar-events' ),
 						'class'   => array(
 							'simcal-field-tiny',
 						),
@@ -935,8 +956,10 @@ class Settings implements Meta_Box {
 		update_post_meta( $post_id, '_calendar_time_format_php', $time_format_php );
 
 		// Date-time separator.
-		$datetime_separator = isset( $_POST['_calendar_datetime_separator'] ) ? sanitize_text_field( $_POST['_calendar_datetime_separator'] ) : ' ';
+		$datetime_separator = isset( $_POST['_calendar_datetime_separator'] ) ? wp_kses_post( $_POST['_calendar_datetime_separator'] ) : ' ';
 		update_post_meta( $post_id, '_calendar_datetime_separator', $datetime_separator );
+		$datetime_separator_spacing = isset( $_POST['_calendar_datetime_separator_spacing'] ) ? sanitize_text_field( $_POST['_calendar_datetime_separator_spacing'] ) : '';
+		update_post_meta( $post_id, '_calendar_datetime_separator_spacing', $datetime_separator_spacing );
 
 		// Week start.
 		$week_start_setting = isset( $_POST['_calendar_week_starts_on_setting'] ) ? sanitize_key( $_POST['_calendar_week_starts_on_setting'] ) : 'use_site';

--- a/includes/admin/metaboxes/settings.php
+++ b/includes/admin/metaboxes/settings.php
@@ -4,12 +4,13 @@
  *
  * @package SimpleCalendar/Admin
  */
+
 namespace SimpleCalendar\Admin\Metaboxes;
 
-use SimpleCalendar\Abstracts\Meta_Box;
 use SimpleCalendar\Abstracts\Calendar;
 use SimpleCalendar\Abstracts\Feed;
 use SimpleCalendar\Abstracts\Field;
+use SimpleCalendar\Abstracts\Meta_Box;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -42,12 +43,10 @@ class Settings implements Meta_Box {
 			<span class="simcal-box-handle">
 				<?php self::settings_handle( $post ); ?>
 			</span>
-
 			<ul class="simcal-tabs">
 				<?php self::settings_tabs( $post ); ?>
 				<?php do_action( 'simcal_settings_meta_tabs' ); ?>
 			</ul>
-
 			<div class="simcal-panels">
 				<div id="events-settings-panel" class="simcal-panel">
 					<?php self::events_settings_panel( $post ); ?>
@@ -67,10 +66,8 @@ class Settings implements Meta_Box {
 					<?php do_action( 'simcal_settings_meta_advanced_panel', $post->ID ); ?>
 				</div>
 			</div>
-
 			<div class="clear">
 			</div>
-
 		</div>
 		<?php
 
@@ -79,7 +76,7 @@ class Settings implements Meta_Box {
 	/**
 	 * Print the meta box settings handle.
 	 *
-	 * @since  3.0.0
+	 * @since   3.0.0
 	 * @access  private
 	 *
 	 * @param \WP_Post $post
@@ -120,7 +117,8 @@ class Settings implements Meta_Box {
 			?>
 			<label for="_feed_type"><span><?php _e( 'Event Source', 'google-calendar-events' ); ?></span>
 				<select name="_feed_type" id="_feed_type">
-					<optgroup label="<?php _ex( 'Get events from', 'From which calendar source to load events from', 'google-calendar-events' ) ?>">
+					<optgroup
+							label="<?php _ex( 'Get events from', 'From which calendar source to load events from', 'google-calendar-events' ) ?>">
 						<?php foreach ( $feed_options as $feed => $name ) { ?>
 							<option value="<?php echo $feed; ?>" <?php selected( $feed, $feed_type, true ); ?>><?php echo $name; ?></option>
 						<?php } ?>
@@ -160,8 +158,10 @@ class Settings implements Meta_Box {
 					$calendar_type_view = isset( $calendar_view[ $calendar ] ) ? $calendar_view[ $calendar ] : '';
 
 					?>
-					<label for="_calendar_view_<?php echo $calendar; ?>"><span><?php _e( 'View', 'google-calendar-events' ); ?></span>
-						<select name="_calendar_view[<?php echo $calendar; ?>]" id="_calendar_view_<?php echo $calendar; ?>">
+					<label for="_calendar_view_<?php echo $calendar; ?>">
+						<span><?php _e( 'View', 'google-calendar-events' ); ?></span>
+						<select name="_calendar_view[<?php echo $calendar; ?>]"
+								id="_calendar_view_<?php echo $calendar; ?>">
 							<optgroup label="<?php _e( 'View to display', 'google-calendar-events' ); ?>">
 								<?php foreach ( $views as $view => $name ) { ?>
 									<option value="<?php echo $view; ?>" <?php selected( $view, $calendar_type_view, true ); ?>><?php echo $name; ?></option>
@@ -188,11 +188,11 @@ class Settings implements Meta_Box {
 
 		// Hook to add more tabs.
 		$tabs = apply_filters( 'simcal_settings_meta_tabs_li', array(
-			'events' => array(
-				'label'   => __( 'Events', 'google-calendar-events' ),
-				'target'  => 'events-settings-panel',
-				'class'   => array( 'active' ),
-				'icon'    => 'simcal-icon-event',
+			'events'   => array(
+				'label'  => __( 'Events', 'google-calendar-events' ),
+				'target' => 'events-settings-panel',
+				'class'  => array( 'active' ),
+				'icon'   => 'simcal-icon-event',
 			),
 			'calendar' => array(
 				'label'  => __( 'Appearance', 'google-calendar-events' ),
@@ -204,10 +204,10 @@ class Settings implements Meta_Box {
 
 		// Always keep advanced tab as the last one.
 		$tabs['advanced'] = array(
-			'label'   => __( 'Advanced', 'google-calendar-events' ),
-			'target'  => 'advanced-settings-panel',
-			'class'   => array(),
-			'icon'    => 'simcal-icon-settings',
+			'label'  => __( 'Advanced', 'google-calendar-events' ),
+			'target' => 'advanced-settings-panel',
+			'class'  => array(),
+			'icon'   => 'simcal-icon-settings',
 		);
 
 		// Output the tabs as list items.
@@ -219,7 +219,7 @@ class Settings implements Meta_Box {
 				$class = $tab['class'] ? $tab['class'] : array();
 
 				echo '<li class="' . $key . '-settings ' . $key . '-tab ' . implode( ' ', $class ) . '" data-tab="' . $key . '">';
-				echo    '<a href="#' . $tab['target'] . '"><i class="' . $icon . '" ></i> <span>' . esc_html( $tab['label'] ) . '</span></a>';
+				echo '<a href="#' . $tab['target'] . '"><i class="' . $icon . '" ></i> <span>' . esc_html( $tab['label'] ) . '</span></a>';
 				echo '</li>';
 			}
 		}
@@ -238,193 +238,211 @@ class Settings implements Meta_Box {
 		?>
 		<table>
 			<thead>
-			<tr><th colspan="2"><?php _e( 'Event Settings', 'google-calendar-events' ); ?></th></tr>
+				<tr>
+					<th colspan="2"><?php _e( 'Event Settings', 'google-calendar-events' ); ?></th>
+				</tr>
 			</thead>
 			<tbody class="simcal-panel-section simcal-panel-section-events-range">
-			<tr class="simcal-panel-field">
-				<th><label for="_calendar_begins"><?php _e( 'Calendar Start', 'google-calendar-events' ); ?></label></th>
-				<td>
-					<?php
+				<tr class="simcal-panel-field">
+					<th>
+						<label for="_calendar_begins"><?php _e( 'Calendar Start', 'google-calendar-events' ); ?></label>
+					</th>
+					<td>
+						<?php
 
-					$calendar_begins = esc_attr( get_post_meta( $post->ID, '_calendar_begins', true ) );
-					$calendar_begins_nth = max( absint( get_post_meta( $post->ID, '_calendar_begins_nth', true ) ), 1 );
-					$calendar_begins_nth_show = in_array( $calendar_begins, array(
-						'days_before',
-						'days_after',
-						'weeks_before',
-						'weeks_after',
-						'months_before',
-						'months_after',
-						'years_before',
-						'years_after',
-					) );
+						$calendar_begins          = esc_attr( get_post_meta( $post->ID, '_calendar_begins', true ) );
+						$calendar_begins_nth      = max( absint( get_post_meta( $post->ID, '_calendar_begins_nth', true ) ), 1 );
+						$calendar_begins_nth_show = in_array( $calendar_begins, array(
+							'days_before',
+							'days_after',
+							'weeks_before',
+							'weeks_after',
+							'months_before',
+							'months_after',
+							'years_before',
+							'years_after',
+						) );
 
-					simcal_print_field( array(
-						'type'       => 'standard',
-						'subtype'    => 'number',
-						'name'       => '_calendar_begins_nth',
-						'id'         => '_calendar_begins_nth',
-						'value'      => strval( $calendar_begins_nth ),
-						'attributes' => array(
-							'min' => '1',
-						),
-						'class'   => array(
-							'simcal-field-inline',
-							'simcal-field-tiny',
-						),
-						'style'      => ! $calendar_begins_nth_show ? array( 'display' => 'none' ) : '',
-					) );
+						simcal_print_field( array(
+							'type'       => 'standard',
+							'subtype'    => 'number',
+							'name'       => '_calendar_begins_nth',
+							'id'         => '_calendar_begins_nth',
+							'value'      => strval( $calendar_begins_nth ),
+							'attributes' => array(
+								'min' => '1',
+							),
+							'class'      => array(
+								'simcal-field-inline',
+								'simcal-field-tiny',
+							),
+							'style'      => ! $calendar_begins_nth_show ? array( 'display' => 'none' ) : '',
+						) );
 
-					?>
-					<select name="_calendar_begins"
-							id="_calendar_begins"
-							class="simcal-field simcal-field-select simcal-field-inline simcal-field-switch-other">
-						<optgroup label="<?php _e( 'Days', 'google-calendar-events' ); ?>">
-							<option value="today"
-									data-hide-fields="_calendar_begins_custom_date,_calendar_begins_nth"
-								<?php selected( 'today', $calendar_begins, true ); ?>><?php _e( 'Today', 'google-calendar-events' ); ?></option>
-							<option value="now"
-									data-hide-fields="_calendar_begins_custom_date,_calendar_begins_nth"
-								<?php selected( 'now', $calendar_begins, true ); ?>><?php _e( 'Now', 'google-calendar-events' ); ?></option>
+						?>
+						<select name="_calendar_begins"
+								id="_calendar_begins"
+								class="simcal-field simcal-field-select simcal-field-inline simcal-field-switch-other">
+							<optgroup label="<?php _e( 'Days', 'google-calendar-events' ); ?>">
+								<option value="today"
+										data-hide-fields="_calendar_begins_custom_date,_calendar_begins_nth"
+									<?php selected( 'today', $calendar_begins, true ); ?>><?php _e( 'Today', 'google-calendar-events' ); ?></option>
+								<option value="now"
+										data-hide-fields="_calendar_begins_custom_date,_calendar_begins_nth"
+									<?php selected( 'now', $calendar_begins, true ); ?>><?php _e( 'Now', 'google-calendar-events' ); ?></option>
+								<option value="days_before"
+										data-hide-field="_calendar_begins_custom_date"
+										data-show-field="_calendar_begins_nth" <?php selected( 'days_before', $calendar_begins, true ); ?>><?php _e( 'Day(s) before today', 'google-calendar-events' ); ?></option>
+								<option value="days_after"
+										data-hide-field="_calendar_begins_custom_date"
+										data-show-field="_calendar_begins_nth" <?php selected( 'days_after', $calendar_begins, true ); ?>><?php _e( 'Day(s) after today', 'google-calendar-events' ); ?></option>
+							</optgroup>
+							<optgroup label="<?php _e( 'Weeks', 'google-calendar-events' ); ?>">
+								<option value="this_week"
+										data-hide-fields="_calendar_begins_custom_date,_calendar_begins_nth"
+									<?php selected( 'this_week', $calendar_begins, true ); ?>><?php _e( 'This week', 'google-calendar-events' ); ?></option>
+								<option value="weeks_before"
+										data-hide-field="_calendar_begins_custom_date"
+										data-show-field="_calendar_begins_nth" <?php selected( 'weeks_before', $calendar_begins, true ); ?>><?php _e( 'Week(s) before current', 'google-calendar-events' ); ?></option>
+								<option value="weeks_after"
+										data-hide-field="_calendar_begins_custom_date"
+										data-show-field="_calendar_begins_nth" <?php selected( 'weeks_after', $calendar_begins, true ); ?>><?php _e( 'Week(s) after current', 'google-calendar-events' ); ?></option>
+							</optgroup>
+							<optgroup label="<?php _e( 'Months', 'google-calendar-events' ); ?>">
+								<option value="this_month"
+										data-hide-fields="_calendar_begins_custom_date,_calendar_begins_nth"
+									<?php selected( 'this_month', $calendar_begins, true ); ?>><?php _e( 'This month', 'google-calendar-events' ); ?></option>
+								<option value="months_before"
+										data-hide-field="_calendar_begins_custom_date"
+										data-show-field="_calendar_begins_nth" <?php selected( 'months_before', $calendar_begins, true ); ?>><?php _e( 'Month(s) before current', 'google-calendar-events' ); ?></option>
+								<option value="months_after"
+										data-hide-field="_calendar_begins_custom_date"
+										data-show-field="_calendar_begins_nth" <?php selected( 'months_after', $calendar_begins, true ); ?>><?php _e( 'Month(s) after current', 'google-calendar-events' ); ?></option>
+							</optgroup>
+							<optgroup label="<?php _e( 'Years', 'google-calendar-events' ); ?>">
+								<option value="this_year"
+										data-hide-fields="_calendar_begins_custom_date,_calendar_begins_nth"
+									<?php selected( 'this_year', $calendar_begins, true ); ?>><?php _e( 'This year', 'google-calendar-events' ); ?></option>
+								<option value="years_before"
+										data-show-field="_calendar_begins_nth" <?php selected( 'years_before', $calendar_begins, true ); ?>><?php _e( 'Year(s) before current', 'google-calendar-events' ); ?></option>
+								<option value="years_after"
+										data-hide-field="_calendar_begins_custom_date"
+										data-show-field="_calendar_begins_nth" <?php selected( 'years_after', $calendar_begins, true ); ?>><?php _e( 'Year(s) after current', 'google-calendar-events' ); ?></option>
+							</optgroup>
+							<optgroup label="<?php _e( 'Other', 'google-calendar-events' ); ?>">
+								<option value="custom_date"
+										data-hide-field="_calendar_begins_nth"
+										data-show-field="_calendar_begins_custom_date" <?php selected( 'custom_date', $calendar_begins, true ); ?>><?php _e( 'Specific date', 'google-calendar-events' ); ?></option>
+							</optgroup>
+						</select>
+						<?php
+
+						simcal_print_field( array(
+							'type'  => 'date-picker',
+							'name'  => '_calendar_begins_custom_date',
+							'id'    => '_calendar_begins_custom_date',
+							'value' => get_post_meta( $post->ID, '_calendar_begins_custom_date', true ),
+							'class' => array(
+								'simcal-field-inline',
+							),
+							'style' => 'custom_date' != $calendar_begins ? array( 'display' => 'none' ) : '',
+						) );
+
+						?>
+						<i class="simcal-icon-help simcal-help-tip"
+						   data-tip="<?php _e( 'The calendar default opening date. It will automatically adapt based on the chosen calendar type.', 'google-calendar-events' ); ?>"></i>
+					</td>
+				</tr>
+				<tr class="simcal-panel-field">
+					<th>
+						<label for="_feed_earliest_event_date"><?php _e( 'Earliest Event', 'google-calendar-events' ); ?></label>
+					</th>
+					<td>
+						<?php
+
+						$earliest_event_saved = get_post_meta( $post->ID, '_feed_earliest_event_date', true );
+						$earliest_event       = false == $earliest_event_saved ? 'months_before' : esc_attr( $earliest_event_saved );
+
+						simcal_print_field( array(
+							'type'       => 'standard',
+							'subtype'    => 'number',
+							'name'       => '_feed_earliest_event_date_range',
+							'id'         => '_feed_earliest_event_date_range',
+							'value'      => strval( max( absint( get_post_meta( $post->ID, '_feed_earliest_event_date_range', true ) ), 1 ) ),
+							'attributes' => array(
+								'min' => '1',
+							),
+							'class'      => array(
+								'simcal-field-inline',
+								'simcal-field-tiny',
+							),
+							'style'      => ( 'now' != $earliest_event ) && ( 'today' != $earliest_event ) ? array( 'display' => 'none' ) : '',
+						) );
+
+						?>
+						<select name="_feed_earliest_event_date"
+								id="_feed_earliest_event_date"
+								class="simcal-field simcal-field-select simcal-field-inline simcal-field-switch-other">
+							<option value="calendar_start"
+									data-hide-field="_feed_earliest_event_date_range" <?php selected( 'calendar_start', $earliest_event, true ); ?>><?php _e( 'Same as start date', 'google-calendar-events' ); ?></option>
 							<option value="days_before"
-									data-hide-field="_calendar_begins_custom_date"
-									data-show-field="_calendar_begins_nth" <?php selected( 'days_before', $calendar_begins, true ); ?>><?php _e( 'Day(s) before today', 'google-calendar-events' ); ?></option>
-							<option value="days_after"
-									data-hide-field="_calendar_begins_custom_date"
-									data-show-field="_calendar_begins_nth" <?php selected( 'days_after', $calendar_begins, true ); ?>><?php _e( 'Day(s) after today', 'google-calendar-events' ); ?></option>
-						</optgroup>
-						<optgroup label="<?php _e( 'Weeks', 'google-calendar-events' ); ?>">
-							<option value="this_week"
-									data-hide-fields="_calendar_begins_custom_date,_calendar_begins_nth"
-								<?php selected( 'this_week', $calendar_begins, true ); ?>><?php _e( 'This week', 'google-calendar-events' ); ?></option>
+									data-show-field="_feed_earliest_event_date_range" <?php selected( 'days_before', $earliest_event, true ); ?>><?php _e( 'Day(s) before start date', 'google-calendar-events' ); ?></option>
 							<option value="weeks_before"
-									data-hide-field="_calendar_begins_custom_date"
-									data-show-field="_calendar_begins_nth" <?php selected( 'weeks_before', $calendar_begins, true ); ?>><?php _e( 'Week(s) before current', 'google-calendar-events' ); ?></option>
-							<option value="weeks_after"
-									data-hide-field="_calendar_begins_custom_date"
-									data-show-field="_calendar_begins_nth" <?php selected( 'weeks_after', $calendar_begins, true ); ?>><?php _e( 'Week(s) after current', 'google-calendar-events' ); ?></option>
-						</optgroup>
-						<optgroup label="<?php _e( 'Months', 'google-calendar-events' ); ?>">
-							<option value="this_month"
-									data-hide-fields="_calendar_begins_custom_date,_calendar_begins_nth"
-								<?php selected( 'this_month', $calendar_begins, true ); ?>><?php _e( 'This month', 'google-calendar-events' ); ?></option>
+									data-show-field="_feed_earliest_event_date_range" <?php selected( 'weeks_before', $earliest_event, true ); ?>><?php _e( 'Week(s) before start date', 'google-calendar-events' ); ?></option>
 							<option value="months_before"
-									data-hide-field="_calendar_begins_custom_date"
-									data-show-field="_calendar_begins_nth" <?php selected( 'months_before', $calendar_begins, true ); ?>><?php _e( 'Month(s) before current', 'google-calendar-events' ); ?></option>
-							<option value="months_after"
-									data-hide-field="_calendar_begins_custom_date"
-									data-show-field="_calendar_begins_nth" <?php selected( 'months_after', $calendar_begins, true ); ?>><?php _e( 'Month(s) after current', 'google-calendar-events' ); ?></option>
-						</optgroup>
-						<optgroup label="<?php _e( 'Years', 'google-calendar-events' ); ?>">
-							<option value="this_year"
-									data-hide-fields="_calendar_begins_custom_date,_calendar_begins_nth"
-								<?php selected( 'this_year', $calendar_begins, true ); ?>><?php _e( 'This year', 'google-calendar-events' ); ?></option>
+									data-show-field="_feed_earliest_event_date_range" <?php selected( 'months_before', $earliest_event, true ); ?>><?php _e( 'Month(s) before start date', 'google-calendar-events' ); ?></option>
 							<option value="years_before"
-									data-show-field="_calendar_begins_nth" <?php selected( 'years_before', $calendar_begins, true ); ?>><?php _e( 'Year(s) before current', 'google-calendar-events' ); ?></option>
+									data-show-field="_feed_earliest_event_date_range" <?php selected( 'years_before', $earliest_event, true ); ?>><?php _e( 'Year(s) before start date', 'google-calendar-events' ); ?></option>
+						</select>
+						<i class="simcal-icon-help simcal-help-tip"
+						   data-tip="<?php _e( 'Set the date for the earliest possible event to show in calendar. There will not be events before this date.', 'google-calendar-events' ); ?>"></i>
+					</td>
+				</tr>
+				<tr class="simcal-panel-field">
+					<th>
+						<label for="_feed_latest_event_date"><?php _e( 'Latest Event', 'google-calendar-events' ); ?></label>
+					</th>
+					<td>
+						<?php
+
+						$latest_event_saved = get_post_meta( $post->ID, '_feed_latest_event_date', true );
+						$latest_event       = false == $latest_event_saved ? 'years_after' : esc_attr( $latest_event_saved );
+
+						simcal_print_field( array(
+							'type'       => 'standard',
+							'subtype'    => 'number',
+							'name'       => '_feed_latest_event_date_range',
+							'id'         => '_feed_latest_event_date_range',
+							'value'      => strval( max( absint( get_post_meta( $post->ID, '_feed_latest_event_date_range', true ) ), 1 ) ),
+							'attributes' => array(
+								'min' => '1',
+							),
+							'class'      => array(
+								'simcal-field-inline',
+								'simcal-field-tiny',
+							),
+							'style'      => 'indefinite' != $latest_event ? array( 'display' => 'none' ) : '',
+						) );
+
+						?>
+						<select name="_feed_latest_event_date"
+								id="_feed_latest_event_date"
+								class="simcal-field simcal-field-select simcal-field-inline simcal-field-switch-other">
+							<option value="calendar_start"
+									data-hide-field="_feed_latest_event_date_range" <?php selected( 'calendar_start', $earliest_event, true ); ?>><?php _e( 'Day end of start date', 'google-calendar-events' ); ?></option>
+							<option value="days_after"
+									data-show-field="_feed_latest_event_date_range" <?php selected( 'days_after', $latest_event, true ); ?>><?php _e( 'Day(s) after start date', 'google-calendar-events' ); ?></option>
+							<option value="weeks_after"
+									data-show-field="_feed_latest_event_date_range" <?php selected( 'weeks_after', $latest_event, true ); ?>><?php _e( 'Weeks(s) after start date', 'google-calendar-events' ); ?></option>
+							<option value="months_after"
+									data-show-field="_feed_latest_event_date_range" <?php selected( 'months_after', $latest_event, true ); ?>><?php _e( 'Month(s) after start date', 'google-calendar-events' ); ?></option>
 							<option value="years_after"
-									data-hide-field="_calendar_begins_custom_date"
-									data-show-field="_calendar_begins_nth" <?php selected( 'years_after', $calendar_begins, true ); ?>><?php _e( 'Year(s) after current', 'google-calendar-events' ); ?></option>
-						</optgroup>
-						<optgroup label="<?php _e( 'Other', 'google-calendar-events' ); ?>">
-							<option value="custom_date"
-									data-hide-field="_calendar_begins_nth"
-									data-show-field="_calendar_begins_custom_date" <?php selected( 'custom_date', $calendar_begins, true ); ?>><?php _e( 'Specific date', 'google-calendar-events' ); ?></option>
-						</optgroup>
-					</select>
-					<?php
-
-					simcal_print_field( array(
-						'type'    => 'date-picker',
-						'name'    => '_calendar_begins_custom_date',
-						'id'      => '_calendar_begins_custom_date',
-						'value'   => get_post_meta( $post->ID, '_calendar_begins_custom_date', true ),
-						'class' => array(
-							'simcal-field-inline',
-						),
-						'style'   => 'custom_date' != $calendar_begins ? array( 'display' => 'none' ) : '',
-					) );
-
-					?>
-					<i class="simcal-icon-help simcal-help-tip"
-					   data-tip="<?php _e( 'The calendar default opening date. It will automatically adapt based on the chosen calendar type.', 'google-calendar-events' ); ?>"></i>
-				</td>
-			</tr>
-			<tr class="simcal-panel-field">
-				<th><label for="_feed_earliest_event_date"><?php _e( 'Earliest Event', 'google-calendar-events' ); ?></label></th>
-				<td>
-					<?php
-
-					$earliest_event_saved = get_post_meta( $post->ID, '_feed_earliest_event_date', true );
-					$earliest_event = false == $earliest_event_saved ? 'months_before' : esc_attr( $earliest_event_saved );
-
-					simcal_print_field( array(
-						'type'       => 'standard',
-						'subtype'    => 'number',
-						'name'       => '_feed_earliest_event_date_range',
-						'id'         => '_feed_earliest_event_date_range',
-						'value'      => strval( max( absint( get_post_meta( $post->ID, '_feed_earliest_event_date_range', true ) ), 1 ) ),
-						'attributes' => array(
-							'min' => '1',
-						),
-						'class'   => array(
-							'simcal-field-inline',
-							'simcal-field-tiny',
-						),
-						'style'      => ( 'now' != $earliest_event ) && ( 'today' != $earliest_event ) ? array( 'display' => 'none' ) : '',
-					) );
-
-					?>
-					<select name="_feed_earliest_event_date"
-							id="_feed_earliest_event_date"
-							class="simcal-field simcal-field-select simcal-field-inline simcal-field-switch-other">
-						<option value="calendar_start" data-hide-field="_feed_earliest_event_date_range" <?php selected( 'calendar_start', $earliest_event, true ); ?>><?php _e( 'Same as start date', 'google-calendar-events' ); ?></option>
-						<option value="days_before"    data-show-field="_feed_earliest_event_date_range" <?php selected( 'days_before', $earliest_event, true ); ?>><?php _e( 'Day(s) before start date', 'google-calendar-events' ); ?></option>
-						<option value="weeks_before"   data-show-field="_feed_earliest_event_date_range" <?php selected( 'weeks_before', $earliest_event, true ); ?>><?php _e( 'Week(s) before start date', 'google-calendar-events' ); ?></option>
-						<option value="months_before"  data-show-field="_feed_earliest_event_date_range" <?php selected( 'months_before', $earliest_event, true ); ?>><?php _e( 'Month(s) before start date', 'google-calendar-events' ); ?></option>
-						<option value="years_before"   data-show-field="_feed_earliest_event_date_range" <?php selected( 'years_before', $earliest_event, true ); ?>><?php _e( 'Year(s) before start date', 'google-calendar-events' ); ?></option>
-					</select>
-					<i class="simcal-icon-help simcal-help-tip"
-					   data-tip="<?php _e( 'Set the date for the earliest possible event to show in calendar. There will not be events before this date.', 'google-calendar-events' ); ?>"></i>
-				</td>
-			</tr>
-			<tr class="simcal-panel-field">
-				<th><label for="_feed_latest_event_date"><?php _e( 'Latest Event', 'google-calendar-events' ); ?></label></th>
-				<td>
-					<?php
-
-					$latest_event_saved = get_post_meta( $post->ID, '_feed_latest_event_date', true );
-					$latest_event = false == $latest_event_saved ? 'years_after' : esc_attr( $latest_event_saved );
-
-					simcal_print_field( array(
-						'type'       => 'standard',
-						'subtype'    => 'number',
-						'name'       => '_feed_latest_event_date_range',
-						'id'         => '_feed_latest_event_date_range',
-						'value'      => strval( max( absint( get_post_meta( $post->ID, '_feed_latest_event_date_range', true ) ), 1 ) ),
-						'attributes' => array(
-							'min' => '1',
-						),
-						'class'      => array(
-							'simcal-field-inline',
-							'simcal-field-tiny',
-						),
-						'style'      => 'indefinite' != $latest_event ? array( 'display' => 'none' ) : '',
-					) );
-
-					?>
-					<select name="_feed_latest_event_date"
-							id="_feed_latest_event_date"
-							class="simcal-field simcal-field-select simcal-field-inline simcal-field-switch-other">
-						<option value="calendar_start" data-hide-field="_feed_latest_event_date_range" <?php selected( 'calendar_start', $earliest_event, true ); ?>><?php _e( 'Day end of start date', 'google-calendar-events' ); ?></option>
-						<option value="days_after"     data-show-field="_feed_latest_event_date_range" <?php selected( 'days_after', $latest_event, true ); ?>><?php _e( 'Day(s) after start date', 'google-calendar-events' ); ?></option>
-						<option value="weeks_after"    data-show-field="_feed_latest_event_date_range" <?php selected( 'weeks_after', $latest_event, true ); ?>><?php _e( 'Weeks(s) after start date', 'google-calendar-events' ); ?></option>
-						<option value="months_after"   data-show-field="_feed_latest_event_date_range" <?php selected( 'months_after', $latest_event, true ); ?>><?php _e( 'Month(s) after start date', 'google-calendar-events' ); ?></option>
-						<option value="years_after"    data-show-field="_feed_latest_event_date_range" <?php selected( 'years_after', $latest_event, true ); ?>><?php _e( 'Year(s) after start date', 'google-calendar-events' ); ?></option>
-					</select>
-					<i class="simcal-icon-help simcal-help-tip"
-					   data-tip="<?php _e( 'Set the date for the latest possible event to show on calendar. There will not be events after this date.', 'google-calendar-events' ); ?>"></i>
-				</td>
-			</tr>
+									data-show-field="_feed_latest_event_date_range" <?php selected( 'years_after', $latest_event, true ); ?>><?php _e( 'Year(s) after start date', 'google-calendar-events' ); ?></option>
+						</select>
+						<i class="simcal-icon-help simcal-help-tip"
+						   data-tip="<?php _e( 'Set the date for the latest possible event to show on calendar. There will not be events after this date.', 'google-calendar-events' ); ?>"></i>
+					</td>
+				</tr>
 			</tbody>
 		</table>
 		<?php
@@ -444,87 +462,97 @@ class Settings implements Meta_Box {
 		?>
 		<table>
 			<thead>
-			<tr><th colspan="2"><?php _e( 'Miscellaneous', 'google-calendar-events' ); ?></th></tr>
+				<tr>
+					<th colspan="2"><?php _e( 'Miscellaneous', 'google-calendar-events' ); ?></th>
+				</tr>
 			</thead>
 			<tbody class="simcal-panel-section">
-			<tr class="simcal-panel-field">
-				<th><label for="_calendar_is_static"><?php _e( 'Static Calendar', 'google-calendar-events' ); ?></label></th>
-				<td>
-					<?php
+				<tr class="simcal-panel-field">
+					<th>
+						<label for="_calendar_is_static"><?php _e( 'Static Calendar', 'google-calendar-events' ); ?></label>
+					</th>
+					<td>
+						<?php
 
-					$fixed = get_post_meta( $post->ID, '_calendar_is_static', true );
+						$fixed = get_post_meta( $post->ID, '_calendar_is_static', true );
 
-					simcal_print_field( array(
-						'type'    => 'checkbox',
-						'name'    => '_calendar_is_static',
-						'id'      => '_calendar_is_static',
-						'tooltip' => __( 'Remove the navigation arrows and fix the calendar view to its initial state.', 'google-calendar-events' ),
-						'value'   => 'yes' == $fixed ? 'yes' : 'no',
-						'text'    => __( 'Yes (hide navigation arrows)', 'google-calendar-events' ),
-					) );
+						simcal_print_field( array(
+							'type'    => 'checkbox',
+							'name'    => '_calendar_is_static',
+							'id'      => '_calendar_is_static',
+							'tooltip' => __( 'Remove the navigation arrows and fix the calendar view to its initial state.', 'google-calendar-events' ),
+							'value'   => 'yes' == $fixed ? 'yes' : 'no',
+							'text'    => __( 'Yes (hide navigation arrows)', 'google-calendar-events' ),
+						) );
 
-					?>
-				</td>
-			</tr>
-			<tr class="simcal-panel-field">
-				<th><label for="_no_events_message"><?php _e( 'No Events Message', 'google-calendar-events' ); ?></label></th>
-				<td>
-					<?php
+						?>
+					</td>
+				</tr>
+				<tr class="simcal-panel-field">
+					<th>
+						<label for="_no_events_message"><?php _e( 'No Events Message', 'google-calendar-events' ); ?></label>
+					</th>
+					<td>
+						<?php
 
-					simcal_print_field( array(
-						'type'    => 'textarea',
-						'name'    => '_no_events_message',
-						'id'      => '_no_events_message',
-						'tooltip' => __( 'Some calendars may display a message when no events are found. You can change the default message here.', 'google-calendar-events' ),
-						'value'   => get_post_meta( $post->ID, '_no_events_message', true ),
-						'placeholder' => __( 'There are no upcoming events.', 'google-calendar-events' ),
-					) );
+						simcal_print_field( array(
+							'type'        => 'textarea',
+							'name'        => '_no_events_message',
+							'id'          => '_no_events_message',
+							'tooltip'     => __( 'Some calendars may display a message when no events are found. You can change the default message here.', 'google-calendar-events' ),
+							'value'       => get_post_meta( $post->ID, '_no_events_message', true ),
+							'placeholder' => __( 'There are no upcoming events.', 'google-calendar-events' ),
+						) );
 
-					?>
-				</td>
-			</tr>
-			<tr class="simcal-panel-field">
-				<th><label for="_event_formatting"><?php _e( 'Event Formatting', 'google-calendar-events' ); ?></label></th>
-				<td>
-					<?php
+						?>
+					</td>
+				</tr>
+				<tr class="simcal-panel-field">
+					<th>
+						<label for="_event_formatting"><?php _e( 'Event Formatting', 'google-calendar-events' ); ?></label>
+					</th>
+					<td>
+						<?php
 
-					$event_formatting = get_post_meta( $post->ID, '_event_formatting', true );
+						$event_formatting = get_post_meta( $post->ID, '_event_formatting', true );
 
-					simcal_print_field( array(
-						'type'    => 'select',
-						'name'    => '_event_formatting',
-						'id'      => '_event_formatting',
-						'tooltip' => __( 'How to preserve line breaks and paragraphs in the event template builder.', 'google-calendar-events' ),
-						'value'   => $event_formatting,
-						'default' => 'preserve_linebreaks',
-						'options' => array(
-							'preserve_linebreaks' => __( 'Preserve line breaks, auto paragraphs (default)', 'google-calendar-events' ),
-							'no_linebreaks'       => __( 'No line breaks, auto paragraphs', 'google-calendar-events' ),
-							'none'                => __( 'No line breaks, no auto paragraphs', 'google-calendar-events' ),
-						),
-					) );
+						simcal_print_field( array(
+							'type'    => 'select',
+							'name'    => '_event_formatting',
+							'id'      => '_event_formatting',
+							'tooltip' => __( 'How to preserve line breaks and paragraphs in the event template builder.', 'google-calendar-events' ),
+							'value'   => $event_formatting,
+							'default' => 'preserve_linebreaks',
+							'options' => array(
+								'preserve_linebreaks' => __( 'Preserve line breaks, auto paragraphs (default)', 'google-calendar-events' ),
+								'no_linebreaks'       => __( 'No line breaks, auto paragraphs', 'google-calendar-events' ),
+								'none'                => __( 'No line breaks, no auto paragraphs', 'google-calendar-events' ),
+							),
+						) );
 
-					?>
-				</td>
-			</tr>
-			<tr class="simcal-panel-field">
-				<th><label for="_poweredby"><?php _e( 'Powered By', 'google-calendar-events' ); ?></label></th>
-				<td>
-					<?php
+						?>
+					</td>
+				</tr>
+				<tr class="simcal-panel-field">
+					<th>
+						<label for="_poweredby"><?php _e( 'Powered By', 'google-calendar-events' ); ?></label>
+					</th>
+					<td>
+						<?php
 
-					$poweredby = get_post_meta( $post->ID, '_poweredby', true );
+						$poweredby = get_post_meta( $post->ID, '_poweredby', true );
 
-					simcal_print_field( array(
-						'type'    => 'checkbox',
-						'name'    => '_poweredby',
-						'id'      => '_poweredby',
-						'value'   => 'yes' == $poweredby ? 'yes' : 'no',
-						'text'    => __( 'Yes, Simple Calendar rocks! Show some love with a little link below this calendar.', 'google-calendar-events' ),
-					) );
+						simcal_print_field( array(
+							'type'  => 'checkbox',
+							'name'  => '_poweredby',
+							'id'    => '_poweredby',
+							'value' => 'yes' == $poweredby ? 'yes' : 'no',
+							'text'  => __( 'Yes, Simple Calendar rocks! Show some love with a little link below this calendar.', 'google-calendar-events' ),
+						) );
 
-					?>
-				</td>
-			</tr>
+						?>
+					</td>
+				</tr>
 			</tbody>
 		</table>
 		<?php
@@ -544,262 +572,296 @@ class Settings implements Meta_Box {
 		?>
 		<table>
 			<thead>
-			<tr><th colspan="2"><?php _e( 'Date and Time', 'google-calendar-events' ); ?></th></tr>
+				<tr>
+					<th colspan="2"><?php _e( 'Date and Time', 'google-calendar-events' ); ?></th>
+				</tr>
 			</thead>
 			<tbody class="simcal-panel-section simcal-panel-datetime-formatting">
-			<tr class="simcal-panel-field">
-				<th><label for="_calendar_timezone_setting"><?php _e( 'Timezone', 'google-calendar-events' ); ?></label></th>
-				<td>
-					<?php
+				<tr class="simcal-panel-field">
+					<th>
+						<label for="_calendar_timezone_setting"><?php _e( 'Timezone', 'google-calendar-events' ); ?></label>
+					</th>
+					<td>
+						<?php
 
-					$timezone_wordpress = simcal_get_wp_timezone();
-					$timezone_default   = $timezone_wordpress ? $timezone_wordpress : 'UTC';
-					$timezone_setting   = esc_attr( get_post_meta( $post->ID, '_feed_timezone_setting', true ) );
-					$timezone           = esc_attr( get_post_meta( $post->ID, '_feed_timezone', true ) );
-					$timezone           = $timezone ? $timezone : $timezone_default;
-					$show_use_calendar  = isset( simcal_get_feed( $post )->type );
+						$timezone_wordpress = simcal_get_wp_timezone();
+						$timezone_default   = $timezone_wordpress ? $timezone_wordpress : 'UTC';
+						$timezone_setting   = esc_attr( get_post_meta( $post->ID, '_feed_timezone_setting', true ) );
+						$timezone           = esc_attr( get_post_meta( $post->ID, '_feed_timezone', true ) );
+						$timezone           = $timezone ? $timezone : $timezone_default;
+						$show_use_calendar  = isset( simcal_get_feed( $post )->type );
 
-					if ( $show_use_calendar ) {
-						$show_use_calendar = ( simcal_get_feed( $post )->type !== 'grouped-calendars' ? 1 : 0 );
-					} else {
-						$show_use_calendar = true;
-					}
+						if ( $show_use_calendar ) {
+							$show_use_calendar = ( simcal_get_feed( $post )->type !== 'grouped-calendars' ? 1 : 0 );
+						} else {
+							$show_use_calendar = true;
+						}
 
-					?>
-					<select name="_feed_timezone_setting"
-							id="_feed_timezone_setting"
-							class="simcal-field simcal-field-select simcal-field-inline simcal-field-show-other"
-							data-show-field-on-choice="true">
-						<option value="use_site" <?php selected( 'use_site', $timezone_setting, true ); ?>><?php printf( _x( 'Site default', 'Use this site default setting', 'google-calendar-events' ) . ' (%s)', $timezone_default ); ?></option>
-						<?php if ( $show_use_calendar ) { ?>
-							<option id="use_calendar" value="use_calendar" data-show-field="_use_calendar_warning" <?php selected( 'use_calendar', $timezone_setting, true ); ?>><?php _ex( 'Event source default', 'Use the calendar default setting', 'google-calendar-events' ); ?></option>
-						<?php } ?>
-						<option value="use_custom" data-show-field="_feed_timezone" <?php selected( 'use_custom', $timezone_setting, true ); ?>><?php _ex( 'Custom', 'Use a custom setting', 'google-calendar-events' ); ?></option>
-					</select>
-					<select name="_feed_timezone"
-							id="_feed_timezone"
-							class="simcal-field simcal-field-select simcal-field-inline"
-						<?php echo 'use_custom' != $timezone_setting ? 'style="display: none;"' : ''; ?>>
-						<?php echo wp_timezone_choice( $timezone ); ?>
-					</select>
-					<i class="simcal-icon-help simcal-help-tip" data-tip="<?php _e( 'Using a different timezone may alter the date and time display of your calendar events. We recommended using the site default timezone.', 'google-calendar-events' ); ?>"></i>
-					<p id="_use_calendar_warning" style="display: none;" class="simcal-field">
-						<span class="attention"><?php _e( 'Warning', 'google-calendar-events' ); ?>:</span>
-						<?php _e( 'Setting this to <code>Event source default</code> can at times cause unexpected results. Please test thoroughly.', 'google-calendar-events' ); ?>
-						<a href="http://docs.simplecalendar.io/timezone-settings/" target="_blank"><?php _e( 'See details.', 'google-calendar-events' ); ?></a>
-					</p>
-				</td>
-			</tr>
-			<tr class="simcal-panel-field">
-				<th><label for="_calendar_date_format_setting"><?php _e( 'Date Format', 'google-calendar-events' ); ?></label></th>
-				<td>
-					<?php
-
-					$date_format_setting = esc_attr( get_post_meta( $post->ID, '_calendar_date_format_setting', true ) );
-					$date_format_default = esc_attr( get_option( 'date_format' ) );
-					$date_format = esc_attr( get_post_meta( $post->ID, '_calendar_date_format', true ) );
-					$date_format_php = esc_attr( get_post_meta( $post->ID, '_calendar_date_format_php', true ) );
-					$date_format_php = $date_format_php ? $date_format_php : $date_format_default;
-
-					?>
-					<select name="_calendar_date_format_setting"
-							id="_calendar_date_format_setting"
-							class="simcal-field simcal-field-select simcal-field-show-other">
-						<option value="use_site" data-show-field="_calendar_date_format_default" <?php selected( 'use_site', $date_format_setting, true ); ?>><?php  _ex( 'Site default', 'Use this site default setting', 'google-calendar-events' ); ?></option>
-						<option value="use_custom" data-show-field="_calendar_date_format" <?php selected( 'use_custom', $date_format_setting, true ); ?>><?php _ex( 'Custom', 'Use a custom setting', 'google-calendar-events' ); ?></option>
-						<option value="use_custom_php" data-show-field="_calendar_date_format_php_field" <?php selected( 'use_custom_php', $date_format_setting, true ); ?>><?php _e( 'Custom (PHP format)', 'google-calendar-events' ); ?></option>
-					</select>
-					<i class="simcal-icon-help simcal-help-tip" data-tip="<?php _e( 'This option sets how calendars display event dates. It is recommended to keep your site default setting.', 'google-calendar-events' ); ?>"></i>
-					<p id="_calendar_date_format_default" style="<?php echo $date_format_setting != 'use_site' ? 'display: none;' : ''; ?>">
-						<em><?php _e( 'Preview', 'google-calendar-events' ) ?>:</em>&nbsp;&nbsp;
-						<code><?php echo date_i18n( $date_format_default, time() ); ?></code>
-					</p>
-					<?php simcal_print_field( array(
-						'type'    => 'datetime-format',
-						'subtype' => 'date',
-						'name'    => '_calendar_date_format',
-						'id'      => '_calendar_date_format',
-						'value'   => $date_format,
-						'style'   => $date_format_setting != 'use_custom' ? array( 'display' => 'none' ) : '',
-					) ); ?>
-					<div class="simcal-field-datetime-format-php" id="_calendar_date_format_php_field" style="<?php echo $date_format_setting != 'use_custom_php' ? 'display: none;' : ''; ?>">
-						<br>
-						<label for="_calendar_date_format_php">
-							<input type="text"
-								   name="_calendar_date_format_php"
-								   id="_calendar_date_format_php"
-								   class="simcal-field simcal-field-text simcal-field-small"
-								   value="<?php echo $date_format_php; ?>" />
-							<?php printf( __( 'Enter a date format using %s values.', 'google-calendar-events' ), '<a href="//php.net/manual/en/function.date.php" target="_blank">PHP</a>' ); ?>
-						</label>
-						<p>
-							<em><?php _e( 'Preview', 'google-calendar-events' ) ?>:</em>&nbsp;&nbsp;
-							<code><?php echo date_i18n( $date_format_php, time() ); ?></code>
+						?>
+						<select name="_feed_timezone_setting"
+								id="_feed_timezone_setting"
+								class="simcal-field simcal-field-select simcal-field-inline simcal-field-show-other"
+								data-show-field-on-choice="true">
+							<option value="use_site" <?php selected( 'use_site', $timezone_setting, true ); ?>><?php printf( _x( 'Site default', 'Use this site default setting', 'google-calendar-events' ) . ' (%s)', $timezone_default ); ?></option>
+							<?php if ( $show_use_calendar ) { ?>
+								<option id="use_calendar" value="use_calendar"
+										data-show-field="_use_calendar_warning" <?php selected( 'use_calendar', $timezone_setting, true ); ?>><?php _ex( 'Event source default', 'Use the calendar default setting', 'google-calendar-events' ); ?></option>
+							<?php } ?>
+							<option value="use_custom"
+									data-show-field="_feed_timezone" <?php selected( 'use_custom', $timezone_setting, true ); ?>><?php _ex( 'Custom', 'Use a custom setting', 'google-calendar-events' ); ?></option>
+						</select>
+						<select name="_feed_timezone"
+								id="_feed_timezone"
+								class="simcal-field simcal-field-select simcal-field-inline"
+							<?php echo 'use_custom' != $timezone_setting ? 'style="display: none;"' : ''; ?>>
+							<?php echo wp_timezone_choice( $timezone ); ?>
+						</select>
+						<i class="simcal-icon-help simcal-help-tip"
+						   data-tip="<?php _e( 'Using a different timezone may alter the date and time display of your calendar events. We recommended using the site default timezone.', 'google-calendar-events' ); ?>"></i>
+						<p id="_use_calendar_warning" style="display: none;" class="simcal-field">
+							<span class="attention"><?php _e( 'Warning', 'google-calendar-events' ); ?>:</span>
+							<?php _e( 'Setting this to <code>Event source default</code> can at times cause unexpected results. Please test thoroughly.', 'google-calendar-events' ); ?>
+							<a href="http://docs.simplecalendar.io/timezone-settings/"
+							   target="_blank"><?php _e( 'See details.', 'google-calendar-events' ); ?></a>
 						</p>
-					</div>
-				</td>
-			</tr>
-			<tr class="simcal-panel-field">
-				<th><label for="_calendar_datetime_separator"><?php _e( 'Separator', 'google-calendar-events' ); ?></label></th>
-				<td>
-					<?php
+					</td>
+				</tr>
+				<tr class="simcal-panel-field">
+					<th>
+						<label for="_calendar_date_format_setting"><?php _e( 'Date Format', 'google-calendar-events' ); ?></label>
+					</th>
+					<td>
+						<?php
 
-					$separator = get_post_meta( $post->ID, '_calendar_datetime_separator', true );
-					$separator = ( false === $separator ) ? '@' : $separator;
+						$date_format_setting = esc_attr( get_post_meta( $post->ID, '_calendar_date_format_setting', true ) );
+						$date_format_default = esc_attr( get_option( 'date_format' ) );
+						$date_format         = esc_attr( get_post_meta( $post->ID, '_calendar_date_format', true ) );
+						$date_format_php     = esc_attr( get_post_meta( $post->ID, '_calendar_date_format_php', true ) );
+						$date_format_php     = $date_format_php ? $date_format_php : $date_format_default;
 
-					simcal_print_field( array(
-						'type'    => 'standard',
-						'subtype' => 'text',
-						'name'    => '_calendar_datetime_separator',
-						'id'      => '_calendar_datetime_separator',
-						'value'   => $separator,
-						'tooltip' => __( 'Used to divide date and time when both are shown.', 'google-calendar-events' ),
-						'class'   => array(
-							'simcal-field-tiny',
-						),
-					) );
-
-					?>
-				</td>
-			</tr>
-			<tr class="simcal-panel-field">
-				<th><label for="_calendar_datetime_separator_spacing"><?php _e( 'Preserve Separator Spacing', 'google-calendar-events' ); ?></label></th>
-				<td>
-					<?php
-
-					$separator_spacing = get_post_meta( $post->ID, '_calendar_datetime_separator_spacing', true );
-
-					simcal_print_field( array(
-						'type'    => 'checkbox',
-						'name'    => '_calendar_datetime_separator_spacing',
-						'id'      => '_calendar_datetime_separator_spacing',
-						'value'   => 'yes' === $separator_spacing ? 'yes' : 'no',
-						'tooltip' => __( 'Checking this box will use the spacing contained in the separator field above. Otherwise one space on each side of the separator will be used instead.', 'google-calendar-events' ),
-						'class'   => array(
-							'simcal-field-tiny',
-						),
-					) );
-
-					?>
-				</td>
-			</tr>
-			<tr class="simcal-panel-field">
-				<th><label for="_calendar_time_format_setting"><?php _e( 'Time Format', 'google-calendar-events' ); ?></label></th>
-				<td>
-					<?php
-
-					$time_format_setting = esc_attr( get_post_meta( $post->ID, '_calendar_time_format_setting', true ) );
-					$time_format_default = esc_attr( get_option( 'time_format' ) );
-					$time_format = esc_attr( get_post_meta( $post->ID, '_calendar_time_format', true ) );
-					$time_format_php = esc_attr( get_post_meta( $post->ID, '_calendar_time_format_php', true ) );
-					$time_format_php = $time_format_php ? $time_format_php : $time_format_default;
-
-					?>
-					<select name="_calendar_time_format_setting"
-							id="_calendar_time_format_setting"
-							class="simcal-field simcal-field-select simcal-field-show-other">
-						<option value="use_site" data-show-field="_calendar_time_format_default" <?php selected( 'use_site', $time_format_setting, true ); ?>><?php _ex( 'Site default', 'Use this site default setting', 'google-calendar-events' ); ?></option>
-						<option value="use_custom" data-show-field="_calendar_time_format" <?php selected( 'use_custom', $time_format_setting, true ); ?>><?php _ex( 'Custom', 'Use a custom setting', 'google-calendar-events' ); ?></option>
-						<option value="use_custom_php" data-show-field="_calendar_time_format_php_field" <?php selected( 'use_custom_php', $time_format_setting, true ); ?>><?php _e( 'Custom (PHP format)', 'google-calendar-events' ); ?></option>
-					</select>
-					<i class="simcal-icon-help simcal-help-tip" data-tip="<?php _e( 'This option sets how calendars display event times. It is recommended to keep your site default setting.', 'google-calendar-events' ); ?>"></i>
-					<p id="_calendar_time_format_default" style="<?php echo $time_format_setting != 'use_site' ? 'display: none;' : ''; ?>">
-						<em><?php _e( 'Preview', 'google-calendar-events' ) ?>:</em>&nbsp;&nbsp;
-						<code><?php echo date_i18n( $time_format_default, time() ); ?></code>
-					</p>
-					<?php simcal_print_field( array(
-						'type'    => 'datetime-format',
-						'subtype' => 'time',
-						'name'    => '_calendar_time_format',
-						'id'      => '_calendar_time_format',
-						'value'   => $time_format,
-						'style'   => $time_format_setting != 'use_custom' ? array( 'display' => 'none' ) : '',
-					) ); ?>
-					<div class="simcal-field-datetime-format-php" id="_calendar_time_format_php_field" style="<?php echo $time_format_setting != 'use_custom_php' ? 'display: none;' : ''; ?>">
-						<br>
-						<label for="_calendar_date_format_php">
-							<input type="text"
-								   name="_calendar_time_format_php"
-								   id="_calendar_time_format_php"
-								   class="simcal-field simcal-field-text simcal-field-small"
-								   value="<?php echo $time_format_php; ?>"/>
-							<?php printf( __( 'Enter a time format using %s values.', 'google-calendar-events' ), '<a href="//php.net/manual/en/function.date.php" target="_blank">PHP</a>' ); ?>
-						</label>
-						<p>
+						?>
+						<select name="_calendar_date_format_setting"
+								id="_calendar_date_format_setting"
+								class="simcal-field simcal-field-select simcal-field-show-other">
+							<option value="use_site"
+									data-show-field="_calendar_date_format_default" <?php selected( 'use_site', $date_format_setting, true ); ?>><?php _ex( 'Site default', 'Use this site default setting', 'google-calendar-events' ); ?></option>
+							<option value="use_custom"
+									data-show-field="_calendar_date_format" <?php selected( 'use_custom', $date_format_setting, true ); ?>><?php _ex( 'Custom', 'Use a custom setting', 'google-calendar-events' ); ?></option>
+							<option value="use_custom_php"
+									data-show-field="_calendar_date_format_php_field" <?php selected( 'use_custom_php', $date_format_setting, true ); ?>><?php _e( 'Custom (PHP format)', 'google-calendar-events' ); ?></option>
+						</select>
+						<i class="simcal-icon-help simcal-help-tip"
+						   data-tip="<?php _e( 'This option sets how calendars display event dates. It is recommended to keep your site default setting.', 'google-calendar-events' ); ?>"></i>
+						<p id="_calendar_date_format_default"
+						   style="<?php echo $date_format_setting != 'use_site' ? 'display: none;' : ''; ?>">
 							<em><?php _e( 'Preview', 'google-calendar-events' ) ?>:</em>&nbsp;&nbsp;
-							<code><?php echo date_i18n( $time_format_php, time() ); ?></code>
+							<code><?php echo date_i18n( $date_format_default, time() ); ?></code>
 						</p>
-					</div>
-				</td>
-			</tr>
-			<tr class="simcal-panel-field">
-				<th><label for="_calendar_week_starts_on_setting"><?php _e( 'Week Starts On', 'google-calendar-events' ); ?></label></th>
-				<td>
-					<?php
+						<?php simcal_print_field( array(
+							'type'    => 'datetime-format',
+							'subtype' => 'date',
+							'name'    => '_calendar_date_format',
+							'id'      => '_calendar_date_format',
+							'value'   => $date_format,
+							'style'   => $date_format_setting != 'use_custom' ? array( 'display' => 'none' ) : '',
+						) ); ?>
+						<div class="simcal-field-datetime-format-php" id="_calendar_date_format_php_field"
+							 style="<?php echo $date_format_setting != 'use_custom_php' ? 'display: none;' : ''; ?>">
+							<br>
+							<label for="_calendar_date_format_php">
+								<input type="text"
+									   name="_calendar_date_format_php"
+									   id="_calendar_date_format_php"
+									   class="simcal-field simcal-field-text simcal-field-small"
+									   value="<?php echo $date_format_php; ?>"/>
+								<?php printf( __( 'Enter a date format using %s values.', 'google-calendar-events' ), '<a href="//php.net/manual/en/function.date.php" target="_blank">PHP</a>' ); ?>
+							</label>
+							<p>
+								<em><?php _e( 'Preview', 'google-calendar-events' ) ?>:</em>&nbsp;&nbsp;
+								<code><?php echo date_i18n( $date_format_php, time() ); ?></code>
+							</p>
+						</div>
+					</td>
+				</tr>
+				<tr class="simcal-panel-field">
+					<th>
+						<label for="_calendar_datetime_separator"><?php _e( 'Separator', 'google-calendar-events' ); ?></label>
+					</th>
+					<td>
+						<?php
 
-					$week_starts_setting = esc_attr( get_post_meta( $post->ID, '_calendar_week_starts_on_setting', true ) );
-					$week_starts_default = esc_attr( get_option( 'start_of_week' ) );
-					$week_starts = intval( get_post_meta( $post->ID, '_calendar_week_starts_on', true ) );
-					$week_starts = is_numeric( $week_starts ) ? strval( $week_starts ) : $week_starts_default;
+						$separator = get_post_meta( $post->ID, '_calendar_datetime_separator', true );
+						$separator = ( false === $separator ) ? '@' : $separator;
 
-					?>
-					<select
-						name="_calendar_week_starts_on_setting"
-						id="_calendar_week_starts_on_setting"
-						class="simcal-field simcal-field-select simcal-field-inline simcal-field-show-next"
-						data-show-next-if-value="use_custom">
-						<option value="use_site" <?php selected( 'use_site', $week_starts_setting, true ); ?>><?php printf( _x( 'Site default', 'Use this site default setting', 'google-calendar-events' ) . ' (%s)', date_i18n( 'l', strtotime( "Sunday + $week_starts_default Days" ) ) ); ?></option>
-						<option value="use_custom" <?php selected( 'use_custom', $week_starts_setting, true ); ?>><?php _ex( 'Custom', 'Use a custom setting', 'google-calendar-events' ); ?></option>
-					</select>
-					<select
-						name="_calendar_week_starts_on"
-						id="_calendar_week_starts_on"
-						class="simcal-field simcal-field-select simcal-field-inline"
-						<?php echo 'use_custom' != $week_starts_setting ? 'style="display: none;"' : ''; ?>>
-						<?php $day_names = simcal_get_calendar_names_i18n( 'day', 'full' ); ?>
-						<?php for ( $i = 0; $i <= 6; $i++ ) : ?>
-							<option value="<?php echo $i; ?>" <?php selected( $i, $week_starts, true ); ?>><?php echo $day_names[ $i ]; ?></option>
-						<?php endfor; ?>
-					</select>
-					<i class="simcal-icon-help simcal-help-tip" data-tip="<?php _e( 'Some calendars may use this setting to display the start of the week. It is recommended to keep the site default setting.', 'google-calendar-events' ); ?>"></i>
-				</td>
-			</tr>
+						simcal_print_field( array(
+							'type'    => 'standard',
+							'subtype' => 'text',
+							'name'    => '_calendar_datetime_separator',
+							'id'      => '_calendar_datetime_separator',
+							'value'   => $separator,
+							'tooltip' => __( 'Used to divide date and time when both are shown.', 'google-calendar-events' ),
+							'class'   => array(
+								'simcal-field-tiny',
+							),
+						) );
+
+						?>
+					</td>
+				</tr>
+				<tr class="simcal-panel-field">
+					<th>
+						<label for="_calendar_datetime_separator_spacing"><?php _e( 'Preserve Separator Spacing', 'google-calendar-events' ); ?></label>
+					</th>
+					<td>
+						<?php
+						$separator_spacing = get_post_meta( $post->ID, '_calendar_datetime_separator_spacing', true );
+
+						simcal_print_field( array(
+							'type'    => 'checkbox',
+							'name'    => '_calendar_datetime_separator_spacing',
+							'id'      => '_calendar_datetime_separator_spacing',
+							'value'   => 'yes' === $separator_spacing ? 'yes' : 'no',
+							'tooltip' => __( 'Checking this box will use the spacing contained in the separator field above. Otherwise one space on each side of the separator will be used instead.', 'google-calendar-events' ),
+							'class'   => array(
+								'simcal-field-tiny',
+							),
+						) );
+						?>
+					</td>
+				</tr>
+				<tr class="simcal-panel-field">
+					<th>
+						<label for="_calendar_time_format_setting"><?php _e( 'Time Format', 'google-calendar-events' ); ?></label>
+					</th>
+					<td>
+						<?php
+
+						$time_format_setting = esc_attr( get_post_meta( $post->ID, '_calendar_time_format_setting', true ) );
+						$time_format_default = esc_attr( get_option( 'time_format' ) );
+						$time_format         = esc_attr( get_post_meta( $post->ID, '_calendar_time_format', true ) );
+						$time_format_php     = esc_attr( get_post_meta( $post->ID, '_calendar_time_format_php', true ) );
+						$time_format_php     = $time_format_php ? $time_format_php : $time_format_default;
+
+						?>
+						<select name="_calendar_time_format_setting"
+								id="_calendar_time_format_setting"
+								class="simcal-field simcal-field-select simcal-field-show-other">
+							<option value="use_site"
+									data-show-field="_calendar_time_format_default" <?php selected( 'use_site', $time_format_setting, true ); ?>><?php _ex( 'Site default', 'Use this site default setting', 'google-calendar-events' ); ?></option>
+							<option value="use_custom"
+									data-show-field="_calendar_time_format" <?php selected( 'use_custom', $time_format_setting, true ); ?>><?php _ex( 'Custom', 'Use a custom setting', 'google-calendar-events' ); ?></option>
+							<option value="use_custom_php"
+									data-show-field="_calendar_time_format_php_field" <?php selected( 'use_custom_php', $time_format_setting, true ); ?>><?php _e( 'Custom (PHP format)', 'google-calendar-events' ); ?></option>
+						</select>
+						<i class="simcal-icon-help simcal-help-tip"
+						   data-tip="<?php _e( 'This option sets how calendars display event times. It is recommended to keep your site default setting.', 'google-calendar-events' ); ?>"></i>
+						<p id="_calendar_time_format_default"
+						   style="<?php echo $time_format_setting != 'use_site' ? 'display: none;' : ''; ?>">
+							<em><?php _e( 'Preview', 'google-calendar-events' ) ?>:</em>&nbsp;&nbsp;
+							<code><?php echo date_i18n( $time_format_default, time() ); ?></code>
+						</p>
+						<?php simcal_print_field( array(
+							'type'    => 'datetime-format',
+							'subtype' => 'time',
+							'name'    => '_calendar_time_format',
+							'id'      => '_calendar_time_format',
+							'value'   => $time_format,
+							'style'   => $time_format_setting != 'use_custom' ? array( 'display' => 'none' ) : '',
+						) ); ?>
+						<div class="simcal-field-datetime-format-php" id="_calendar_time_format_php_field"
+							 style="<?php echo $time_format_setting != 'use_custom_php' ? 'display: none;' : ''; ?>">
+							<br>
+							<label for="_calendar_date_format_php">
+								<input type="text"
+									   name="_calendar_time_format_php"
+									   id="_calendar_time_format_php"
+									   class="simcal-field simcal-field-text simcal-field-small"
+									   value="<?php echo $time_format_php; ?>"/>
+								<?php printf( __( 'Enter a time format using %s values.', 'google-calendar-events' ), '<a href="//php.net/manual/en/function.date.php" target="_blank">PHP</a>' ); ?>
+							</label>
+							<p>
+								<em><?php _e( 'Preview', 'google-calendar-events' ) ?>:</em>&nbsp;&nbsp;
+								<code><?php echo date_i18n( $time_format_php, time() ); ?></code>
+							</p>
+						</div>
+					</td>
+				</tr>
+				<tr class="simcal-panel-field">
+					<th>
+						<label for="_calendar_week_starts_on_setting"><?php _e( 'Week Starts On', 'google-calendar-events' ); ?></label>
+					</th>
+					<td>
+						<?php
+
+						$week_starts_setting = esc_attr( get_post_meta( $post->ID, '_calendar_week_starts_on_setting', true ) );
+						$week_starts_default = esc_attr( get_option( 'start_of_week' ) );
+						$week_starts         = intval( get_post_meta( $post->ID, '_calendar_week_starts_on', true ) );
+						$week_starts         = is_numeric( $week_starts ) ? strval( $week_starts ) : $week_starts_default;
+
+						?>
+						<select
+								name="_calendar_week_starts_on_setting"
+								id="_calendar_week_starts_on_setting"
+								class="simcal-field simcal-field-select simcal-field-inline simcal-field-show-next"
+								data-show-next-if-value="use_custom">
+							<option value="use_site" <?php selected( 'use_site', $week_starts_setting, true ); ?>><?php printf( _x( 'Site default', 'Use this site default setting', 'google-calendar-events' ) . ' (%s)', date_i18n( 'l', strtotime( "Sunday + $week_starts_default Days" ) ) ); ?></option>
+							<option value="use_custom" <?php selected( 'use_custom', $week_starts_setting, true ); ?>><?php _ex( 'Custom', 'Use a custom setting', 'google-calendar-events' ); ?></option>
+						</select>
+						<select
+								name="_calendar_week_starts_on"
+								id="_calendar_week_starts_on"
+								class="simcal-field simcal-field-select simcal-field-inline"
+							<?php echo 'use_custom' != $week_starts_setting ? 'style="display: none;"' : ''; ?>>
+							<?php $day_names = simcal_get_calendar_names_i18n( 'day', 'full' ); ?>
+							<?php for ( $i = 0; $i <= 6; $i ++ ) : ?>
+								<option value="<?php echo $i; ?>" <?php selected( $i, $week_starts, true ); ?>><?php echo $day_names[ $i ]; ?></option>
+							<?php endfor; ?>
+						</select>
+						<i class="simcal-icon-help simcal-help-tip"
+						   data-tip="<?php _e( 'Some calendars may use this setting to display the start of the week. It is recommended to keep the site default setting.', 'google-calendar-events' ); ?>"></i>
+					</td>
+				</tr>
 			</tbody>
 		</table>
 		<table>
 			<thead>
-			<tr><th colspan="2"><?php _e( 'Cache', 'google-calendar-events' ); ?></th></tr>
+				<tr>
+					<th colspan="2"><?php _e( 'Cache', 'google-calendar-events' ); ?></th>
+				</tr>
 			</thead>
 			<tbody class="simcal-panel-section simcal-panel-section-cache">
-			<?php
+				<?php
 
-			$cache_freq = esc_attr( get_post_meta( $post->ID, '_feed_cache_user_amount', true ) );
-			$cache_unit = esc_attr( get_post_meta( $post->ID, '_feed_cache_user_unit', true ) );
+				$cache_freq = esc_attr( get_post_meta( $post->ID, '_feed_cache_user_amount', true ) );
+				$cache_unit = esc_attr( get_post_meta( $post->ID, '_feed_cache_user_unit', true ) );
 
-			$cache_freq = intval( $cache_freq ) && $cache_freq >= 0 ? $cache_freq : 2;
-			$cache_unit = $cache_unit ? $cache_unit : '3600';
+				$cache_freq = intval( $cache_freq ) && $cache_freq >= 0 ? $cache_freq : 2;
+				$cache_unit = $cache_unit ? $cache_unit : '3600';
 
-			?>
-			<tr class="simcal-panel-field">
-				<th><label for="_feed_cache_user_amount"><?php _ex( 'Refresh Interval', 'Cache maximum interval', 'google-calendar-events' ); ?></label></th>
-				<td>
-					<input type="number"
-						   name="_feed_cache_user_amount"
-						   id="_feed_cache_user_amount"
-						   class="simcal-field simcal-field-number simcal-field-tiny simcal-field-inline"
-						   value="<?php echo $cache_freq; ?>"
-						   min="0" />
-					<select name="_feed_cache_user_unit"
-							id="_feed_cache_user_unit"
-							class="simcal-field simcalfield-select simcal-field-inline">
-						<option value="60" <?php selected( '60', $cache_unit, true ); ?>><?php _e( 'Minute(s)', 'google-calendar-events' ); ?></option>
-						<option value="3600" <?php selected( '3600', $cache_unit, true ); ?>><?php _e( 'Hour(s)', 'google-calendar-events' ); ?></option>
-						<option value="86400" <?php selected( '86400', $cache_unit, true ); ?>><?php _e( 'Day(s)', 'google-calendar-events' ); ?></option>
-						<option value="604800" <?php selected( '604800', $cache_unit, true ); ?>><?php _e( 'Week(s)', 'google-calendar-events' ); ?></option>
-					</select>
-					<i class="simcal-icon-help simcal-help-tip" data-tip="<?php _e( 'If you add, edit or remove events in your calendar very often, you can set a lower interval to refresh the events displayed. Set a higher interval for best performance.', 'google-calendar-events' ); ?>"></i>
-				</td>
-			</tr>
+				?>
+				<tr class="simcal-panel-field">
+					<th>
+						<label for="_feed_cache_user_amount"><?php _ex( 'Refresh Interval', 'Cache maximum interval', 'google-calendar-events' ); ?></label>
+					</th>
+					<td>
+						<input type="number"
+							   name="_feed_cache_user_amount"
+							   id="_feed_cache_user_amount"
+							   class="simcal-field simcal-field-number simcal-field-tiny simcal-field-inline"
+							   value="<?php echo $cache_freq; ?>"
+							   min="0"/>
+						<select name="_feed_cache_user_unit"
+								id="_feed_cache_user_unit"
+								class="simcal-field simcalfield-select simcal-field-inline">
+							<option value="60" <?php selected( '60', $cache_unit, true ); ?>><?php _e( 'Minute(s)', 'google-calendar-events' ); ?></option>
+							<option value="3600" <?php selected( '3600', $cache_unit, true ); ?>><?php _e( 'Hour(s)', 'google-calendar-events' ); ?></option>
+							<option value="86400" <?php selected( '86400', $cache_unit, true ); ?>><?php _e( 'Day(s)', 'google-calendar-events' ); ?></option>
+							<option value="604800" <?php selected( '604800', $cache_unit, true ); ?>><?php _e( 'Week(s)', 'google-calendar-events' ); ?></option>
+						</select>
+						<i class="simcal-icon-help simcal-help-tip"
+						   data-tip="<?php _e( 'If you add, edit or remove events in your calendar very often, you can set a lower interval to refresh the events displayed. Set a higher interval for best performance.', 'google-calendar-events' ); ?>"></i>
+					</td>
+				</tr>
 			</tbody>
 		</table>
 		<?php
@@ -824,20 +886,20 @@ class Settings implements Meta_Box {
 
 				?>
 				<tbody class="simcal-panel-section simcal-panel-section-<?php echo esc_attr( $section ); ?>">
-				<?php foreach ( $fields as $key => $field ) :
+					<?php foreach ( $fields as $key => $field ) :
 
-					$value            = get_post_meta( $post_id, $key, true );
-					$field['value']   = $value ? $value : ( isset( $field['default'] ) ? $field['default'] : '' );
-					$the_field = simcal_get_field( $field ); ?>
-
-					<?php if ( $the_field instanceof Field ) : ?>
-					<tr class="simcal-panel-field">
-						<th><label for="<?php echo $the_field->id ?>"><?php echo $the_field->title; ?></label></th>
-						<td><?php $the_field->html(); ?></td>
-					</tr>
-				<?php endif; ?>
-
-				<?php endforeach; ?>
+						$value = get_post_meta( $post_id, $key, true );
+						$field['value'] = $value ? $value : ( isset( $field['default'] ) ? $field['default'] : '' );
+						$the_field = simcal_get_field( $field ); ?>
+						<?php if ( $the_field instanceof Field ) : ?>
+						<tr class="simcal-panel-field">
+							<th>
+								<label for="<?php echo $the_field->id ?>"><?php echo $the_field->title; ?></label>
+							</th>
+							<td><?php $the_field->html(); ?></td>
+						</tr>
+					<?php endif; ?>
+					<?php endforeach; ?>
 				</tbody>
 				<?php
 
@@ -935,8 +997,8 @@ class Settings implements Meta_Box {
 		$feed_timezone_setting = isset( $_POST['_feed_timezone_setting'] ) ? sanitize_key( $_POST['_feed_timezone_setting'] ) : 'use_calendar';
 		update_post_meta( $post_id, '_feed_timezone_setting', $feed_timezone_setting );
 		$default_timezone = simcal_get_wp_timezone();
-		$feed_timezone = $default_timezone ? $default_timezone : 'UTC';
-		$feed_timezone = isset( $_POST['_feed_timezone'] ) ? sanitize_text_field( $_POST['_feed_timezone'] ) : $feed_timezone;
+		$feed_timezone    = $default_timezone ? $default_timezone : 'UTC';
+		$feed_timezone    = isset( $_POST['_feed_timezone'] ) ? sanitize_text_field( $_POST['_feed_timezone'] ) : $feed_timezone;
 		update_post_meta( $post_id, '_feed_timezone', $feed_timezone );
 
 		// Date format.
@@ -974,7 +1036,7 @@ class Settings implements Meta_Box {
 			$unit   = is_numeric( $_POST['_feed_cache_user_unit'] ) ? absint( $_POST['_feed_cache_user_unit'] ) : 3600;
 			update_post_meta( $post_id, '_feed_cache_user_amount', $amount );
 			update_post_meta( $post_id, '_feed_cache_user_unit', $unit );
-			$cache  = ( ( $amount * $unit ) > 0 ) ? $amount * $unit : 1;
+			$cache = ( ( $amount * $unit ) > 0 ) ? $amount * $unit : 1;
 		}
 		update_post_meta( $post_id, '_feed_cache', $cache );
 

--- a/includes/events/event-builder.php
+++ b/includes/events/event-builder.php
@@ -708,11 +708,11 @@ class Event_Builder {
 
 		if ( ! $event->whole_day ) {
 
-			$time_start = $this->calendar->datetime_separator . ' <span class="simcal-event-start simcal-event-start-time" ' . 'data-event-start="' . $start_ts . '" ' . 'data-event-format="' . $this->calendar->time_format . '" ' . 'itemprop="startDate" content="' . $start_iso . '">' . date_i18n( $this->calendar->time_format, strtotime( $start->toDateTimeString() ) ) . '</span> ';
+			$time_start = $this->calendar->datetime_separator . '<span class="simcal-event-start simcal-event-start-time" ' . 'data-event-start="' . $start_ts . '" ' . 'data-event-format="' . $this->calendar->time_format . '" ' . 'itemprop="startDate" content="' . $start_iso . '">' . date_i18n( $this->calendar->time_format, strtotime( $start->toDateTimeString() ) ) . '</span>';
 
 			if ( $end instanceof Carbon ) {
 
-				$time_end = ' <span class="simcal-event-end simcal-event-end-time" ' . 'data-event-end="' . $end_ts . '" ' . 'data-event-format="' . $this->calendar->time_format . '" ' . 'itemprop="endDate" content="' . $end_iso . '">' . date_i18n( $this->calendar->time_format, strtotime( $end->toDateTimeString() ) ) . '</span> ';
+				$time_end = '<span class="simcal-event-end simcal-event-end-time" ' . 'data-event-end="' . $end_ts . '" ' . 'data-event-format="' . $this->calendar->time_format . '" ' . 'itemprop="endDate" content="' . $end_iso . '">' . date_i18n( $this->calendar->time_format, strtotime( $end->toDateTimeString() ) ) . '</span>';
 
 			}
 
@@ -720,11 +720,11 @@ class Event_Builder {
 
 		if ( $event->multiple_days ) {
 
-			$output = ' <span class="simcal-event-start simcal-event-start-date" ' . 'data-event-start="' . $start_ts . '" ' . 'data-event-format="' . $this->calendar->date_format . '" ' . 'itemprop="startDate" content="' . $start_iso . '">' . date_i18n( $this->calendar->date_format, strtotime( $start->toDateTimeString() ) ) . '</span> ' . $time_start;
+			$output = '<span class="simcal-event-start simcal-event-start-date" ' . 'data-event-start="' . $start_ts . '" ' . 'data-event-format="' . $this->calendar->date_format . '" ' . 'itemprop="startDate" content="' . $start_iso . '">' . date_i18n( $this->calendar->date_format, strtotime( $start->toDateTimeString() ) ) . '</span>' . $time_start;
 
 			if ( $end instanceof Carbon ) {
 
-				$output .= '-' . ' <span class="simcal-event-start simcal-event-end-date" ' . 'data-event-start="' . $end_ts . '" ' . 'data-event-format="' . $this->calendar->date_format . '" ' . 'itemprop="endDate" content="' . $end_iso . '">' . date_i18n( $this->calendar->date_format, strtotime( $end->toDateTimeString() ) ) . '</span> ' . $time_end;
+				$output .= '-' . '<span class="simcal-event-start simcal-event-end-date" ' . 'data-event-start="' . $end_ts . '" ' . 'data-event-format="' . $this->calendar->date_format . '" ' . 'itemprop="endDate" content="' . $end_iso . '">' . date_i18n( $this->calendar->date_format, strtotime( $end->toDateTimeString() ) ) . '</span>' . $time_end;
 			}
 
 		} else {
@@ -732,7 +732,7 @@ class Event_Builder {
 			$time_end = ! empty( $time_start ) && ! empty( $time_end ) ? ' - ' . $time_end : '';
 
 			// All-day events also need startDate for schema data.
-			$output = ' <span class="simcal-event-start simcal-event-start-date" ' . 'data-event-start="' . $start_ts . '" ' . 'data-event-format="' . $this->calendar->date_format . '" ' . 'itemprop="startDate" content="' . $start_iso . '">' . date_i18n( $this->calendar->date_format, strtotime( $start->toDateTimeString() ) ) . '</span> ' . $time_start . $time_end;
+			$output = '<span class="simcal-event-start simcal-event-start-date" ' . 'data-event-start="' . $start_ts . '" ' . 'data-event-format="' . $this->calendar->date_format . '" ' . 'itemprop="startDate" content="' . $start_iso . '">' . date_i18n( $this->calendar->date_format, strtotime( $start->toDateTimeString() ) ) . '</span>' . $time_start . $time_end;
 
 		}
 

--- a/includes/events/event-builder.php
+++ b/includes/events/event-builder.php
@@ -724,7 +724,7 @@ class Event_Builder {
 
 			if ( $end instanceof Carbon ) {
 
-				$output .= '-' . '<span class="simcal-event-start simcal-event-end-date" ' . 'data-event-start="' . $end_ts . '" ' . 'data-event-format="' . $this->calendar->date_format . '" ' . 'itemprop="endDate" content="' . $end_iso . '">' . date_i18n( $this->calendar->date_format, strtotime( $end->toDateTimeString() ) ) . '</span>' . $time_end;
+				$output .= '-' . '<span class="simcal-event-start simcal-event-end-date" ' . 'data-event-start="' . $end_ts . '" ' . 'data-event-format="' . $this->calendar->date_format . '" ' . 'itemprop="endDate" content="' . $end_iso . '">' . date_i18n( $this->calendar->date_format, strtotime( $end->toDateTimeString() ) ) . '</span>' . $this->calendar->datetime_separator . $time_end;
 			}
 
 		} else {

--- a/readme.txt
+++ b/readme.txt
@@ -96,6 +96,10 @@ We'd love your help! Here's a few things you can do:
 
 == Changelog ==
 
+= 3.1.10 - TBD =
+
+* Feature: Allow administrators to set spacing within the datetime separator under individual advanced calendar settings.
+
 = 3.1.9 - December 9, 2016 =
 
 * Feature: Add [if-today] and [if-not-today] event template tags. Props [@followfung](https://github.com/followfung)


### PR DESCRIPTION
- Add new checkbox to allow administrators to use spacing around the datetime separator. Defaults to one space as it is currently.
- Update formatting for datetime separator output on front end.
- Add entry to readme.txt for this feature.