### PR TITLE
add starting time to grid-view

### DIFF
--- a/includes/calendars/admin/default-calendar-admin.php
+++ b/includes/calendars/admin/default-calendar-admin.php
@@ -110,6 +110,21 @@ class Default_Calendar_Admin {
 				</td>
 			</tr>
 			<tr class="simcal-panel-field simcal-default-calendar-grid" style="display: none;">
+				<th><label for="_default_calendar_time_in_grid"><?php _e( 'Show Start Time in Grid', 'google-calendar-events' ); ?></label></th>
+				<td>
+					<?php
+					$start_time = get_post_meta( $post_id, '_default_calendar_time_in_grid', true );
+					simcal_print_field( array(
+						'type'        => 'checkbox',
+						'name'        => '_default_calendar_time_in_grid',
+						'id'          => '_default_calendar_time_in_grid',
+						'tooltip'     => __( 'Show the starting time of an event in calendar grid.', 'google-calendar-events' ),
+						'value'       => 'yes' == $start_time ? 'yes' : 'no',
+					) );
+					?>
+				</td>
+			</tr>
+			<tr class="simcal-panel-field simcal-default-calendar-grid" style="display: none;">
 				<th><label for="_default_calendar_trim_titles"><?php _e( 'Trim Event Titles', 'google-calendar-events' ); ?></label></th>
 				<td>
 					<?php
@@ -430,6 +445,10 @@ class Default_Calendar_Admin {
 		// Grid event bubbles action.
 		$bubbles = isset( $_POST['_default_calendar_event_bubble_trigger'] ) ? esc_attr( $_POST['_default_calendar_event_bubble_trigger'] ) : 'hover';
 		update_post_meta( $post_id, '_default_calendar_event_bubble_trigger', $bubbles );
+
+		// Show start time in grid
+		$start_time = isset( $_POST['_default_calendar_time_in_grid'] ) ? 'yes' : 'no';
+		update_post_meta( $post_id, '_default_calendar_time_in_grid', $start_time );
 
 		// Trim event titles characters length.
 		$trim = isset( $_POST['_default_calendar_trim_titles'] ) ? 'yes' : 'no';

--- a/includes/calendars/default-calendar.php
+++ b/includes/calendars/default-calendar.php
@@ -43,6 +43,14 @@ class Default_Calendar extends Calendar {
 	public $trim_titles = -1;
 
 	/**
+	 * Show start time in grid view.
+	 *
+	 * @access public
+	 * @var bool
+	 */
+	public $show_start_time = false;
+
+	/**
 	 * Event bubbles action trigger.
 	 *
 	 * @access public
@@ -176,6 +184,11 @@ class Default_Calendar extends Calendar {
 			// Use hover to open event bubbles.
 			if ( 'hover' == get_post_meta( $this->id, '_default_calendar_event_bubble_trigger', true ) ) {
 				$this->event_bubble_trigger = 'hover';
+			}
+
+			// Show start times.
+			if ( 'yes' == get_post_meta( $this->id, '_default_calendar_time_in_grid', true ) ) {
+				$this->show_start_times = true;
 			}
 
 			// Trim long event titles.

--- a/includes/calendars/views/default-calendar-grid.php
+++ b/includes/calendars/views/default-calendar-grid.php
@@ -435,6 +435,11 @@ class Default_Calendar_Grid implements Calendar_View {
 
 						// Event title in list.
 						$title = ! empty( $event->title ) ? trim( $event->title ) : __( 'Event', 'google-calendar-events' );
+						if ( $calendar->show_start_times ) {
+							$start = Carbon::createFromTimestamp( $event->start, $calendar->timezone );
+							$title = $start->format($calendar->time_format) . " " . $title;
+						}
+
 						if ( $calendar->trim_titles >= 1 ) {
 							$title = strlen( $title ) > $calendar->trim_titles ? mb_substr( $title, 0, $calendar->trim_titles ) . '&hellip;' : $title;
 						}


### PR DESCRIPTION
This feature allows the starting time of an event to be displayed in
grid view. It is controllable by an option in the calendar's admin
panel.

In order to be backwards-compatible it defaults to not showing the
starting time. The time is formatted according to the calendars
settings.

fixes #56