### PR TITLE
bump required php version for v3.1.11+

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@ Contributors: simplecalendar, sureswiftcapital, pderksen, nickyoung87, nekojira,
 Tags: google calendar, calendar, calendars, google, event calendar, custom calendar, custom calendars, event, events
 Requires at least: 4.2
 Tested up to: 4.9
+Requires PHP: 5.5+
 Stable tag: 3.1.11
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -97,7 +98,7 @@ We'd love your help! Here's a few things you can do:
 == Changelog ==
 
 = 3.1.11 - December 27, 2017 =
-* Dev: Update Google API Client libraries to v2. NOTE: Version 5.4+ for PHP now required.
+* Dev: Update Google API Client libraries to v2. NOTE: Version 5.5+ for PHP now required.
 * Fix: Default calendar list view not showing pro calendar coloring when Calendar Settings > Appearance > Limit Visible Events is set.
 
 = 3.1.10 - August 22, 2017 =


### PR DESCRIPTION
Bumping php version required for v3.1.11 to PHP version 5.5+