### PR TITLE
Require PHP 5.5 and bump plugin version

### DIFF
--- a/google-calendar-events.php
+++ b/google-calendar-events.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $this_plugin_path      = trailingslashit( dirname( __FILE__ ) );
 $this_plugin_dir       = plugin_dir_url( __FILE__ );
 $this_plugin_constants = array(
-	'SIMPLE_CALENDAR_VERSION'   => '3.1.11',
+	'SIMPLE_CALENDAR_VERSION'   => '3.1.11.1',
 	'SIMPLE_CALENDAR_MAIN_FILE' => __FILE__,
 	'SIMPLE_CALENDAR_URL'       => $this_plugin_dir,
 	'SIMPLE_CALENDAR_ASSETS'    => $this_plugin_dir . 'assets/',

--- a/google-calendar-events.php
+++ b/google-calendar-events.php
@@ -40,7 +40,7 @@ include_once 'includes/wp-requirements.php';
 
 // Check plugin requirements before loading plugin.
 $this_plugin_checks = new SimCal_WP_Requirements( 'Simple Calendar', plugin_basename( __FILE__ ), array(
-		'PHP'        => '5.4',
+		'PHP'        => '5.5',
 		'WordPress'  => '4.2',
 		'Extensions' => array(
 			'curl',

--- a/google-calendar-events.php
+++ b/google-calendar-events.php
@@ -5,7 +5,7 @@
  * Description: Add Google Calendar events to your WordPress site in minutes. Beautiful calendar displays. Fully responsive.
  * Author:      Simple Calendar
  * Author URI:  https://simplecalendar.io
- * Version:     3.1.11
+ * Version:     3.1.11.1
  * Text Domain: google-calendar-events
  * Domain Path: /i18n
  *

--- a/readme.txt
+++ b/readme.txt
@@ -100,7 +100,7 @@ We'd love your help! Here's a few things you can do:
 * Fix: Bump required PHP version to match 3.1.11 requiring PHP 5.5 so site's running older versions don't crash when updating.
 
 = 3.1.11 - January 2, 2018 =
-* Dev: Update Google API Client libraries to v2. NOTE: Version 5.4+ for PHP now required.
+* Dev: Update Google API Client libraries to v2. NOTE: Version 5.5+ for PHP now required.
 * Fix: Default calendar list view not showing pro calendar coloring when Calendar Settings > Appearance > Limit Visible Events is set.
 
 = 3.1.10 - August 22, 2017 =

--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,7 @@
 Contributors: simplecalendar, sureswiftcapital, pderksen, nickyoung87, nekojira, rosshanney
 Tags: google calendar, calendar, calendars, google, event calendar, custom calendar, custom calendars, event, events
 Requires at least: 4.2
+Requires PHP: 5.5+
 Tested up to: 4.9
 Stable tag: 3.1.11.1
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: simplecalendar, sureswiftcapital, pderksen, nickyoung87, nekojira,
 Tags: google calendar, calendar, calendars, google, event calendar, custom calendar, custom calendars, event, events
 Requires at least: 4.2
 Tested up to: 4.9
-Stable tag: 3.1.11
+Stable tag: 3.1.11.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -96,7 +96,10 @@ We'd love your help! Here's a few things you can do:
 
 == Changelog ==
 
-= 3.1.11 - December 27, 2017 =
+= 3.1.11.1 - January 3, 2018 =
+* Fix: Bump required PHP version to match 3.1.11 requiring PHP 5.5 so site's running older versions don't crash when updating.
+
+= 3.1.11 - January 2, 2018 =
 * Dev: Update Google API Client libraries to v2. NOTE: Version 5.4+ for PHP now required.
 * Fix: Default calendar list view not showing pro calendar coloring when Calendar Settings > Appearance > Limit Visible Events is set.
 


### PR DESCRIPTION
The latest plugin release (3.1.11) bumped the PHP version required to 5.5. Users on older PHP versions reported their site crashing when attempting to update the plugin. This hotfix prevents that from happening.