### PR TITLE
Swap back to v1 google api client lilbrary

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,13 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "php": ">=5.4",
+    "php": ">=5.3",
     "ext-curl": "*",
     "ext-iconv": "*",
     "ext-json": "*",
     "ext-mbstring": "*",
     "composer/installers": "1.x",
-    "google/apiclient": "2.x",
+    "google/apiclient": "1.x",
     "nesbot/carbon": "1.x",
     "erusev/parsedown": "1.x",
     "mexitek/phpcolors": "dev-master"


### PR DESCRIPTION
This PR is to address the reported issues of the plugin no longer being compatible with older versions of PHP.