### PR TITLE
fix Google API event query sorting

### DIFF
--- a/includes/feeds/google.php
+++ b/includes/feeds/google.php
@@ -394,7 +394,7 @@ class Google extends Feed {
 			$args = array();
 
 			// Expand recurring events.
-			if ( $this->google_events_recurring == 'show' ) {
+			if ( 'show' === $this->google_events_recurring ) {
 				$args['singleEvents'] = true;
 			}
 
@@ -432,6 +432,13 @@ class Google extends Feed {
 				}
 				$timeMax->setTimestamp( $latest_event );
 				$args['timeMax'] = $timeMax->toRfc3339String();
+			}
+
+			// Trying to order by startTime for non-single events throws
+			// Google v3 API 400 error - "The requested ordering is not available for the particular query.".
+			// Only set this conditionally.
+			if ( true === $args['singleEvents'] ) {
+				$args['orderBy'] = 'startTime';
 			}
 
 			// Query events in calendar.


### PR DESCRIPTION
Fixes an issue discussed in https://app.activecollab.com/137470/projects/44?modal=Task-7236-44 where setting up an event list calendar for the next 3 events wouldn't pull in the correct events due to API sorting order.