### PR TITLE
Unset duplicate calendar js localization variable

### DIFF
--- a/assets/css/admin-add-calendar.min.css
+++ b/assets/css/admin-add-calendar.min.css
@@ -1,4 +1,4 @@
-/*! Simple Calendar - 3.1.15
+/*! Simple Calendar - 3.1.16
  * https://simplecalendar.io
  * Copyright (c) Moonstone Media 2018
  * Licensed GPLv2+ */

--- a/assets/css/admin.min.css
+++ b/assets/css/admin.min.css
@@ -1,4 +1,4 @@
-/*! Simple Calendar - 3.1.15
+/*! Simple Calendar - 3.1.16
  * https://simplecalendar.io
  * Copyright (c) Moonstone Media 2018
  * Licensed GPLv2+ */

--- a/assets/css/default-calendar-grid.min.css
+++ b/assets/css/default-calendar-grid.min.css
@@ -1,4 +1,4 @@
-/*! Simple Calendar - 3.1.15
+/*! Simple Calendar - 3.1.16
  * https://simplecalendar.io
  * Copyright (c) Moonstone Media 2018
  * Licensed GPLv2+ */

--- a/assets/css/default-calendar-list.min.css
+++ b/assets/css/default-calendar-list.min.css
@@ -1,4 +1,4 @@
-/*! Simple Calendar - 3.1.15
+/*! Simple Calendar - 3.1.16
  * https://simplecalendar.io
  * Copyright (c) Moonstone Media 2018
  * Licensed GPLv2+ */

--- a/assets/js/admin-add-calendar.min.js
+++ b/assets/js/admin-add-calendar.min.js
@@ -1,4 +1,4 @@
-/*! Simple Calendar - 3.1.15
+/*! Simple Calendar - 3.1.16
  * https://simplecalendar.io
  * Copyright (c) Moonstone Media 2018
  * Licensed GPLv2+ */

--- a/assets/js/admin.min.js
+++ b/assets/js/admin.min.js
@@ -1,4 +1,4 @@
-/*! Simple Calendar - 3.1.15
+/*! Simple Calendar - 3.1.16
  * https://simplecalendar.io
  * Copyright (c) Moonstone Media 2018
  * Licensed GPLv2+ */

--- a/assets/js/default-calendar.min.js
+++ b/assets/js/default-calendar.min.js
@@ -1,4 +1,4 @@
-/*! Simple Calendar - 3.1.15
+/*! Simple Calendar - 3.1.16
  * https://simplecalendar.io
  * Copyright (c) Moonstone Media 2018
  * Licensed GPLv2+ */

--- a/google-calendar-events.php
+++ b/google-calendar-events.php
@@ -5,7 +5,7 @@
  * Description: Add Google Calendar events to your WordPress site in minutes. Beautiful calendar displays. Fully responsive.
  * Author:      Simple Calendar
  * Author URI:  https://simplecalendar.io
- * Version:     3.1.15
+ * Version:     3.1.16
  * Text Domain: google-calendar-events
  * Domain Path: /i18n
  *
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $this_plugin_path      = trailingslashit( dirname( __FILE__ ) );
 $this_plugin_dir       = plugin_dir_url( __FILE__ );
 $this_plugin_constants = array(
-	'SIMPLE_CALENDAR_VERSION'   => '3.1.15',
+	'SIMPLE_CALENDAR_VERSION'   => '3.1.16',
 	'SIMPLE_CALENDAR_MAIN_FILE' => __FILE__,
 	'SIMPLE_CALENDAR_URL'       => $this_plugin_dir,
 	'SIMPLE_CALENDAR_ASSETS'    => $this_plugin_dir . 'assets/',

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -128,6 +128,11 @@ class Assets {
 			}
 		}
 
+		// Prevent duplicate localization variables for default calendar.
+		if ( isset($scripts[1]['simcal-default-calendar']['localize'] ) ) {
+			unset( $scripts[1]['simcal-default-calendar']['localize'] );
+		}
+
 		$this->get_widgets_assets();
 		$this->scripts = apply_filters( 'simcal_front_end_scripts', $scripts, $this->min );
 		// First check if there is a multi-dimensional array of scripts

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -129,7 +129,7 @@ class Assets {
 		}
 
 		// Prevent duplicate localization variables for default calendar.
-		if ( isset($scripts[1]['simcal-default-calendar']['localize'] ) ) {
+		if ( isset( $scripts[1]['simcal-default-calendar']['localize'] ) ) {
 			unset( $scripts[1]['simcal-default-calendar']['localize'] );
 		}
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "Simple-Calendar",
   "title": "Simple Calendar",
   "description": "Add Google Calendar events to your WordPress site.",
-  "version": "3.1.15",
+  "version": "3.1.16",
   "license": "GPLv2+",
   "homepage": "https://simplecalendar.io",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: google calendar, calendar, calendars, google, event calendar, custom calen
 Requires at least: 4.2
 Requires PHP: 5.3+
 Tested up to: 4.9
-Stable tag: 3.1.15
+Stable tag: 3.1.16
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -96,6 +96,9 @@ We'd love your help! Here's a few things you can do:
 8. Attach a calendar to a post or page
 
 == Changelog ==
+
+= 3.1.16 - May 15, 2018 =
+* Fix: Issue with duplicate default calendar JSON data being output.
 
 = 3.1.15 - February 22, 2018 =
 * Fix: Issue with jQuery $.ajax call parameter compatibility with older versions of jQuery.

--- a/readme.txt
+++ b/readme.txt
@@ -97,7 +97,7 @@ We'd love your help! Here's a few things you can do:
 
 == Changelog ==
 
-= 3.1.16 - May 15, 2018 =
+= 3.1.16 - May 22, 2018 =
 * Fix: Issue with duplicate default calendar JSON data being output.
 
 = 3.1.15 - February 22, 2018 =


### PR DESCRIPTION
Fixes issue where loops and creation of localization variables would duplicate the entry for the default calendar.

Ref: https://app.activecollab.com/137470/projects/44/tasks/7702

Also bumps version numbers and adds to changelog for 3.1.16 release version.