### PR TITLE
only register settings on page that needs it

### DIFF
--- a/assets/css/admin-add-calendar.min.css
+++ b/assets/css/admin-add-calendar.min.css
@@ -1,4 +1,4 @@
-/*! Simple Calendar - 3.1.15
+/*! Simple Calendar - 3.1.16
  * https://simplecalendar.io
  * Copyright (c) Moonstone Media 2018
  * Licensed GPLv2+ */

--- a/assets/css/admin.min.css
+++ b/assets/css/admin.min.css
@@ -1,4 +1,4 @@
-/*! Simple Calendar - 3.1.15
+/*! Simple Calendar - 3.1.16
  * https://simplecalendar.io
  * Copyright (c) Moonstone Media 2018
  * Licensed GPLv2+ */

--- a/assets/css/default-calendar-grid.min.css
+++ b/assets/css/default-calendar-grid.min.css
@@ -1,4 +1,4 @@
-/*! Simple Calendar - 3.1.15
+/*! Simple Calendar - 3.1.16
  * https://simplecalendar.io
  * Copyright (c) Moonstone Media 2018
  * Licensed GPLv2+ */

--- a/assets/css/default-calendar-list.min.css
+++ b/assets/css/default-calendar-list.min.css
@@ -1,4 +1,4 @@
-/*! Simple Calendar - 3.1.15
+/*! Simple Calendar - 3.1.16
  * https://simplecalendar.io
  * Copyright (c) Moonstone Media 2018
  * Licensed GPLv2+ */

--- a/assets/js/admin-add-calendar.min.js
+++ b/assets/js/admin-add-calendar.min.js
@@ -1,4 +1,4 @@
-/*! Simple Calendar - 3.1.15
+/*! Simple Calendar - 3.1.16
  * https://simplecalendar.io
  * Copyright (c) Moonstone Media 2018
  * Licensed GPLv2+ */

--- a/assets/js/admin.min.js
+++ b/assets/js/admin.min.js
@@ -1,4 +1,4 @@
-/*! Simple Calendar - 3.1.15
+/*! Simple Calendar - 3.1.16
  * https://simplecalendar.io
  * Copyright (c) Moonstone Media 2018
  * Licensed GPLv2+ */

--- a/assets/js/default-calendar.min.js
+++ b/assets/js/default-calendar.min.js
@@ -1,4 +1,4 @@
-/*! Simple Calendar - 3.1.15
+/*! Simple Calendar - 3.1.16
  * https://simplecalendar.io
  * Copyright (c) Moonstone Media 2018
  * Licensed GPLv2+ */

--- a/google-calendar-events.php
+++ b/google-calendar-events.php
@@ -5,7 +5,7 @@
  * Description: Add Google Calendar events to your WordPress site in minutes. Beautiful calendar displays. Fully responsive.
  * Author:      Simple Calendar
  * Author URI:  https://simplecalendar.io
- * Version:     3.1.15
+ * Version:     3.1.16
  * Text Domain: google-calendar-events
  * Domain Path: /i18n
  *
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $this_plugin_path      = trailingslashit( dirname( __FILE__ ) );
 $this_plugin_dir       = plugin_dir_url( __FILE__ );
 $this_plugin_constants = array(
-	'SIMPLE_CALENDAR_VERSION'   => '3.1.15',
+	'SIMPLE_CALENDAR_VERSION'   => '3.1.16',
 	'SIMPLE_CALENDAR_MAIN_FILE' => __FILE__,
 	'SIMPLE_CALENDAR_URL'       => $this_plugin_dir,
 	'SIMPLE_CALENDAR_ASSETS'    => $this_plugin_dir . 'assets/',

--- a/includes/main.php
+++ b/includes/main.php
@@ -216,7 +216,13 @@ final class Plugin {
 	 * @since 3.0.0
 	 */
 	public function register_settings() {
-		if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
+		if (
+			is_admin()
+			&& ! defined( 'DOING_AJAX' )
+			&& isset( $_GET['page'] )
+			&& 'simple-calendar_settings' === $_GET['page']
+			|| 'update' === $_POST['action']
+		) {
 			$settings = new Admin\Pages();
 			$settings->register_settings( $settings->get_settings() );
 		}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "Simple-Calendar",
   "title": "Simple Calendar",
   "description": "Add Google Calendar events to your WordPress site.",
-  "version": "3.1.15",
+  "version": "3.1.16",
   "license": "GPLv2+",
   "homepage": "https://simplecalendar.io",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: google calendar, calendar, calendars, google, event calendar, custom calen
 Requires at least: 4.2
 Requires PHP: 5.3+
 Tested up to: 4.9
-Stable tag: 3.1.15
+Stable tag: 3.1.16
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -96,6 +96,9 @@ We'd love your help! Here's a few things you can do:
 8. Attach a calendar to a post or page
 
 == Changelog ==
+
+= 3.1.16 - June 6, 2018 =
+* Fix: Issue with slow loading admin calendar settings page.
 
 = 3.1.15 - May 22, 2018 =
 * Fix: Issue with jQuery $.ajax call parameter compatibility with older versions of jQuery.

--- a/readme.txt
+++ b/readme.txt
@@ -98,7 +98,7 @@ We'd love your help! Here's a few things you can do:
 == Changelog ==
 
 = 3.1.16 - June 6, 2018 =
-* Fix: Issue with slow loading admin calendar settings page.
+* Fix: Issue with slow loading admin settings page.
 
 = 3.1.15 - May 22, 2018 =
 * Fix: Issue with jQuery $.ajax call parameter compatibility with older versions of jQuery.


### PR DESCRIPTION
Fixes an issue where the settings get registered on every admin page load, causing slow loading times, by restricting the register settings to only the settings pages they are being displayed on, plus an additional action global var check to prevent error when updating settings.