### PR TITLE
Ensures block editor is disabled for the "calendar" post type.

### DIFF
--- a/includes/functions/gutenberg.php
+++ b/includes/functions/gutenberg.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Disables Gutenberg/block editing on the calendar post type.
+ *
+ * Due to the settings needed, this should be sufficient for now,
+ * but we can revisit block compatibility at a later date.
+ *
+ * @param bool   $can_edit  Gutenberg edit this post type.
+ * @param string $post_type The post type.
+ *
+ * @return bool
+ */
+function simcal_gutenberg_can_edit_post_type( $can_edit, $post_type ) {
+	return ( 'calendar' === $post_type ) ? false : $can_edit;
+}
+
+add_filter( 'use_block_editor_for_post_type', 'simcal_gutenberg_can_edit_post_type', 9999, 2 );
+add_filter( 'gutenberg_can_edit_post_type', 'simcal_gutenberg_can_edit_post_type', 9999, 2 );

--- a/includes/main.php
+++ b/includes/main.php
@@ -128,10 +128,12 @@ final class Plugin {
 		// Functions shared in both back end and front end.
 		include_once 'functions/shared.php';
 
+		// Gutenberg/block editor customizations.
+		include_once 'functions/gutenberg.php';
+
 		// Init custom post types and taxonomies.
 		new Post_Types();
 
-		// Load back end.
 		if ( is_admin() ) {
 			$this->load_admin();
 		} else {


### PR DESCRIPTION
Enabling Gutenberg for the "calendar" post type requires a filter. Although not specifically necessary, this uses that filter to turn off block compatibility for that post type.

Currently turning on Gutenberg for the calendar post type has compatibility issues, namely a white screen for the post add new and edit screens.

Due to the number of shortcodes, etc. in the post content, this seems like a suitable solution for now due to limited number of available hours, as converting these components/settings to blocks may be necessary.