### PR TITLE
Test with latest WP 5.2.2

### DIFF
--- a/includes/assets.php
+++ b/includes/assets.php
@@ -219,7 +219,7 @@ class Assets {
 					$src        = esc_url( $v['src'] );
 					$in_footer  = isset( $v['in_footer'] )   ? $v['in_footer']  : false;
 
-					wp_enqueue_script( $script, $src, array(), SIMPLE_CALENDAR_VERSION, $in_footer );
+					wp_enqueue_script( $script, $src, array( 'jquery' ), SIMPLE_CALENDAR_VERSION, $in_footer );
 
 					if ( ! empty( $v['localize'] ) && is_array( $v['localize'] ) ) {
 						foreach ( $v['localize'] as $object => $l10n ) {


### PR DESCRIPTION
Tested with new WP site using twentynineteen theme and WordPress 5.2.2.  Theme does not include jquery so needed to add it as dependency. 