### PR TITLE
Fix Deprecated: strpos(): Non-string needles error

### DIFF
--- a/includes/functions/shared.php
+++ b/includes/functions/shared.php
@@ -300,7 +300,7 @@ function simcal_default_event_template() {
 function simcal_get_date_format_order( $date_format ) {
 
 	$pos = array(
-		'd' => strpos( $date_format, strpbrk( $date_format, 'Dj' ) ),
+		'd' => strpos( $date_format, strpbrk( $date_format, 'dj' ) ),
 		'm' => strpos( $date_format, strpbrk( $date_format, 'FMmn' ) ),
 		'y' => strpos( $date_format, strpbrk( $date_format, 'Yy' ) ),
 	);


### PR DESCRIPTION
simcal_get_date_format_order function had wrong date format string

Related WP support forum thread:
https://wordpress.org/support/topic/strpos-depracated-in-php-7-3-throwing-errors/