### PR TITLE
Fix calling Parsedown from the global namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,13 @@ phpunit.xml
 # Windows crap
 ehthumbs.db
 Thumbs.db
+includes/vendor/autoload.php
+includes/vendor/composer/autoload_classmap.php
+includes/vendor/composer/autoload_namespaces.php
+includes/vendor/composer/autoload_psr4.php
+includes/vendor/composer/autoload_real.php
+includes/vendor/composer/autoload_static.php
+includes/vendor/composer/ClassLoader.php
+includes/vendor/composer/LICENSE
+vendor/
+third-party/

--- a/includes/events/event-builder.php
+++ b/includes/events/event-builder.php
@@ -670,7 +670,7 @@ return array_merge( array(
 			if ( $allow_html ) {
 				$description = wp_kses_post( $description );
 			} elseif ( $allow_md ) {
-				$markdown    = new \Parsedown();
+				$markdown    = new Parsedown();
 				$description = $markdown->text( wp_strip_all_tags( $description ) );
 			}
 		} else {

--- a/includes/events/event-builder.php
+++ b/includes/events/event-builder.php
@@ -8,6 +8,7 @@ namespace SimpleCalendar\Events;
 
 use SimpleCalendar\plugin_deps\Carbon\Carbon;
 use SimpleCalendar\Abstracts\Calendar;
+use SimpleCalendar\plugin_deps\Parsedown;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -73,6 +73,7 @@ return array(
 			->path( '#^nesbot/#' )
 			->path( '#^symfony/#' )
 			->path( '#^mexitek/#' )
+			->path( '#^erusev/#' )
 			->in( 'vendor' ),
 
 		// Google API service infrastructure classes.


### PR DESCRIPTION
Seen a user with issues using the base plugin i've narrowed it down to me missing removing a \ so its trying to load Parsedown from the global name space which it no longer exists in :(  This fix should sort that.

@nickyoung87 Can you get this merged please so it reduces the impact?