### PR TITLE
Add the ability to get a iCalendar format feed from any calendar

### DIFF
--- a/includes/functions/shared.php
+++ b/includes/functions/shared.php
@@ -127,7 +127,7 @@ function simcal_draw_calendar_ics($post) {
 	foreach($events as $eventarr) {
 		$event = $eventarr[0];
 		$ics .= "BEGIN:VEVENT\n";
-		$ics .="UID:" . $event->ical_id . "\n";
+		$ics .="UID:" . $event->uid . "\n";
 		$ics .="DTSTAMP:" . $event->start_dt->format('Ymd\THis') . "\n";
 		$ics .= "ORGANIZER;CN=" . $event->source . "\n";
 		$ics .= "DTSTART:" . $event->start_dt->format('Ymd\THis') . "\n";

--- a/includes/functions/shared.php
+++ b/includes/functions/shared.php
@@ -126,17 +126,20 @@ function simcal_draw_calendar_ics($post) {
 
 	foreach($events as $eventarr) {
 		$event = $eventarr[0];
-		$ics .= "BEGIN:VEVENT\n";
-		$ics .="UID:" . $event->uid . "\n";
-		$ics .="DTSTAMP:" . $event->start_dt->format('Ymd\THis') . "\n";
-		$ics .= "ORGANIZER;CN=" . $event->source . "\n";
-		$ics .= "DTSTART:" . $event->start_dt->format('Ymd\THis') . "\n";
-		$ics .= "DTEND:" . $event->start_dt->format('Ymd\THis') . "\n";
-		$ics.= "SUMMARY:" . $event->title . "\n";
-		$ics .= "DESCRIPTION:" . str_replace("\n\t\n","\n\t",str_replace("\n","\n\t",$event->description)) . "\n";
-		$ics .= "LOCATION:" . $event->start_location["name"] .';' . $event->start_location["address"] ."\n";
-		$ics .= "GEO:" . $event->start_location["lat"] . ';' . $event->start_location["lng"] . "\n";
-		$ics .= "END:VEVENT\n";
+		if($strpos($ics, $event->uid) == false) {
+			$ics .= "BEGIN:VEVENT\n";
+			$ics .="UID:" . $event->uid . "\n";
+			$ics .="DTSTAMP:" . $event->start_dt->format('Ymd\THis') . "\n";
+			$ics .= "ORGANIZER;CN=" . $event->source . "\n";
+			$ics .= "DTSTART:" . $event->start_dt->format('Ymd\THis') . "\n";
+			$ics .= "DTEND:" . $event->end_dt->format('Ymd\THis') . "\n";
+			$ics.= "SUMMARY:" . $event->title . "\n";
+			$ics .= "DESCRIPTION:" . str_replace("\n\t\n","\n\t",str_replace("\n","\n\t",$event->description)) . "\n";
+			$ics .= "LOCATION:" . $event->start_location["name"] .';' . $event->start_location["address"] ."\n";
+			$ics .= "GEO:" . $event->start_location["lat"] . ';' . $event->start_location["lng"] . "\n";
+			$ics .= "END:VEVENT\n";
+		}
+
 	}
 
 	$ics .= 'END:VCALENDAR';

--- a/includes/functions/shared.php
+++ b/includes/functions/shared.php
@@ -112,32 +112,55 @@ function simcal_get_calendar( $object ) {
 	$objects = \SimpleCalendar\plugin()->objects;
 	return $objects instanceof \SimpleCalendar\Objects ? $objects->get_calendar( $object ) : null;
 }
+/**
+ * Formats strings to ical standard
+ *
+ * @param string $s
+ *
+ * @return string
+ */
+function format_ical_string( $s ) {
+    $r = wordwrap(
+        preg_replace(
+            array( '/,/', '/;/', '/[\r\n]/' ),
+            array( '\,', '\;', '\n' ),
+            $s
+        ), 73, "\n", TRUE
+    );
+
+    // Indent all lines but first:
+    $r = preg_replace( '/\n/', "\n  ", $r );
+
+    return $r;
+}
+
 
 /**
  * Compose and return a ics feed from the calendar
+ * @param  string|int|object|WP_Post $object
  * @return void
  *
  */
 function simcal_draw_calendar_ics($post) {
 	$calendar = simcal_get_calendar($post);
 	$events = $calendar->events;
-	header('Content-Type:text/plain');
-	$ics = "BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//Wordpress/Simple-Calendar\n";
+	header('Content-Type:text/calendar');
+	$ics = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Wordpress/Simple-Calendar\r\n";
 
 	foreach($events as $eventarr) {
 		$event = $eventarr[0];
-		if($strpos($ics, $event->uid) == false) {
-			$ics .= "BEGIN:VEVENT\n";
-			$ics .="UID:" . $event->uid . "\n";
-			$ics .="DTSTAMP:" . $event->start_dt->format('Ymd\THis') . "\n";
-			$ics .= "ORGANIZER;CN=" . $event->source . "\n";
-			$ics .= "DTSTART:" . $event->start_dt->format('Ymd\THis') . "\n";
-			$ics .= "DTEND:" . $event->end_dt->format('Ymd\THis') . "\n";
-			$ics.= "SUMMARY:" . $event->title . "\n";
-			$ics .= "DESCRIPTION:" . str_replace("\n\t\n","\n\t",str_replace("\n","\n\t",$event->description)) . "\n";
-			$ics .= "LOCATION:" . $event->start_location["name"] .';' . $event->start_location["address"] ."\n";
-			$ics .= "GEO:" . $event->start_location["lat"] . ';' . $event->start_location["lng"] . "\n";
-			$ics .= "END:VEVENT\n";
+		if(strpos($ics, $event->uid) == false) {
+			$ics .= "BEGIN:VEVENT\r\n";
+			$ics .="UID:" . $event->uid . "\r\n";
+			$ics .="DTSTAMP:" . $event->start_dt->format('Ymd\THis') . "\r\n";
+			$ics .= "ORGANIZER;CN=" . $event->source . ":MAILTO:".$event->source."\r\n";
+			$ics .= "DTSTART:" . $event->start_dt->format('Ymd\THis') . "\r\n";
+			$ics .= "DTEND:" . $event->end_dt->format('Ymd\THis') . "\r\n";
+			$ics.= "SUMMARY:" . format_ical_string($event->title) . "\r\n";
+			$ics .= "DESCRIPTION:" . format_ical_string($event->description) . "\r\n";
+			$ics .= "LOCATION:" . $event->start_location["name"] .';' . $event->start_location["address"] ."\r\n";
+			$ics .= "GEO:" . $event->start_location["lat"] . ';' . $event->start_location["lng"] . "\r\n";
+			$ics .= "END:VEVENT\r\n";
 		}
 
 	}
@@ -319,11 +342,11 @@ function simcal_default_event_template() {
 
 	$content  = '<strong>' . '[title]' . '</strong>';
 	$content .= "\n\n";
-	$content .= '[when]' . "\n";
+	$content .= '[when]' . "\r\n";
 	$content .= '[location]';
-	$content .= "\n";
+	$content .= "\r\n";
 	$content .= '<div>' . '[description]' . '</div>';
-	$content .= "\n" . '[link newwindow="yes"]' . __( 'See more details', 'google-calendar-events' ) . '[/link]';
+	$content .= "\r\n" . '[link newwindow="yes"]' . __( 'See more details', 'google-calendar-events' ) . '[/link]';
 
 	return apply_filters( 'simcal_default_event_template', $content );
 }

--- a/includes/functions/shared.php
+++ b/includes/functions/shared.php
@@ -114,6 +114,36 @@ function simcal_get_calendar( $object ) {
 }
 
 /**
+ * Compose and return a ics feed from the calendar
+ * @return void
+ *
+ */
+function simcal_draw_calendar_ics($post) {
+	$calendar = simcal_get_calendar($post);
+	$events = $calendar->events;
+	header('Content-Type:text/plain');
+	$ics = "BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//Wordpress/Simple-Calendar\n";
+
+	foreach($events as $eventarr) {
+		$event = $eventarr[0];
+		$ics .= "BEGIN:VEVENT\n";
+		$ics .="UID:" . $event->ical_id . "\n";
+		$ics .="DTSTAMP:" . $event->start_dt->format('Ymd\THis') . "\n";
+		$ics .= "ORGANIZER;CN=" . $event->source . "\n";
+		$ics .= "DTSTART:" . $event->start_dt->format('Ymd\THis') . "\n";
+		$ics .= "DTEND:" . $event->start_dt->format('Ymd\THis') . "\n";
+		$ics.= "SUMMARY:" . $event->title . "\n";
+		$ics .= "DESCRIPTION:" . str_replace("\n\t\n","\n\t",str_replace("\n","\n\t",$event->description)) . "\n";
+		$ics .= "LOCATION:" . $event->start_location["name"] .';' . $event->start_location["address"] ."\n";
+		$ics .= "GEO:" . $event->start_location["lat"] . ';' . $event->start_location["lng"] . "\n";
+		$ics .= "END:VEVENT\n";
+	}
+
+	$ics .= 'END:VCALENDAR';
+	die($ics);
+}
+
+/**
  * Get a calendar view.
  *
  * @since  3.0.0
@@ -140,7 +170,6 @@ function simcal_get_calendar_view( $id = 0, $name = '' ) {
 function simcal_print_calendar( $object ) {
 
 	$calendar = simcal_get_calendar( $object );
-
 	if ( $calendar instanceof \SimpleCalendar\Abstracts\Calendar ) {
 		$calendar->html();
 	}

--- a/includes/main.php
+++ b/includes/main.php
@@ -180,6 +180,13 @@ final class Plugin {
 		}
 	}
 
+public function simcal_ics_action() {
+	global $post;
+	if(isset($post) && $post->post_type == "calendar" && isset($_GET["ics"]) && $_GET["ics"] == true) {
+		simcal_draw_calendar_ics($post);
+	}
+}
+
 	/**
 	 * Init plugin when WordPress initializes.
 	 *
@@ -198,6 +205,8 @@ final class Plugin {
 
 		// Upon init action hook.
 		do_action( 'simcal_init' );
+
+		add_action('template_redirect',array($this, 'simcal_ics_action'), 10 );
 	}
 
 	/**


### PR DESCRIPTION
This PR adds the ability to add `?ics=true` to the end of any calendar URL and get an iCalendar formatted feed generated and returned back. This is useful as the plugin an provide this link to both single and grouped calendars, making mass-sharing of grouped calendars much easier.

Welcome to feedback and/or changes needed to better structure this. So far, I have tested this on the site of JCI Estonia with a  grouped calendar of 10 individual calendars and over 100 events successfully.